### PR TITLE
Fix LipSync not working issue

### DIFF
--- a/Update/init.txt
+++ b/Update/init.txt
@@ -135,5 +135,7 @@ void main()
 	ModSetConfigFontSize(15);
 	ModSetMainFontOutlineWidth(10);
 
+	ModAddArtset("Console", "ゲーム機", "CG");
+
 	CallScript( "flow" );
 }


### PR DESCRIPTION
We're adding support for Ryukishi sprites into the main arcs. It is implemented using a new `ModAddArtset` command in init.txt. See how it's done in [Onikakushi](https://github.com/07th-mod/onikakushi/commit/60f1d01f4e1a70938ceff5955d1a9c1a55bf8af8). In console arcs we can use this command to disable CGAlt completely, which should fix the cases where LipSync didn't work for some ppl in console arcs.