### PR TITLE
Remove shortcuts from scenario screen

### DIFF
--- a/Update/chapterselect.txt
+++ b/Update/chapterselect.txt
@@ -78,11 +78,6 @@ void main()
 		if (LoadValueFromLocalWork( LOCALWORK_NO_RESULT ) == 1) {
 			StopBGM( 2 );
 			PlaySE( 1, "wa_037", 128, 64 );
-			FadeBustshot( 9, FALSE, 0, 0, 0, 0, 1000, TRUE );
-			DrawBustshot(9, "scenario/shortcuts", 0, 0, 0, FALSE, 0, 0, 0, 0, 0, 0, 0, 20, 1000, TRUE );
-			Wait(10000);
-
-			DrawScene( "black", 1000 );
 
 			SetValidityOfSaving( TRUE );
 			CallSection("TaraiDay1");
@@ -114,11 +109,6 @@ void main()
 		if (LoadValueFromLocalWork( LOCALWORK_NO_RESULT ) == 1) {
 			StopBGM( 2 );
 			PlaySE( 1, "wa_037", 128, 64 );
-			FadeBustshot( 9, FALSE, 0, 0, 0, 0, 1000, TRUE );
-			DrawBustshot(9, "scenario/shortcuts", 0, 0, 0, FALSE, 0, 0, 0, 0, 0, 0, 0, 20, 1000, TRUE );
-			Wait(10000);
-
-			DrawScene( "black", 1000 );
 
 			SetValidityOfSaving( TRUE );
 			CallSection("TsukiDay1");
@@ -150,11 +140,6 @@ void main()
 		if (LoadValueFromLocalWork( LOCALWORK_NO_RESULT ) == 1) {
 			StopBGM( 2 );
 			PlaySE( 1, "wa_037", 128, 64 );
-			FadeBustshot( 9, FALSE, 0, 0, 0, 0, 1000, TRUE );
-			DrawBustshot(9, "scenario/shortcuts", 0, 0, 0, FALSE, 0, 0, 0, 0, 0, 0, 0, 20, 1000, TRUE );
-			Wait(10000);
-
-			DrawScene( "black", 1000 );
 
 			SetValidityOfSaving( TRUE );
 			CallSection("SomeDay1");
@@ -186,11 +171,6 @@ void main()
 		if (LoadValueFromLocalWork( LOCALWORK_NO_RESULT ) == 1) {
 			StopBGM( 2 );
 			PlaySE( 1, "wa_037", 128, 64 );
-			FadeBustshot( 9, FALSE, 0, 0, 0, 0, 1000, TRUE );
-			DrawBustshot(9, "scenario/shortcuts", 0, 0, 0, FALSE, 0, 0, 0, 0, 0, 0, 0, 20, 1000, TRUE );
-			Wait(10000);
-
-			DrawScene( "black", 1000 );
 
 			SetValidityOfSaving( TRUE );
 			CallSection("KageDay1");
@@ -222,11 +202,6 @@ void main()
 		if (LoadValueFromLocalWork( LOCALWORK_NO_RESULT ) == 1) {
 			StopBGM( 2 );
 			PlaySE( 1, "wa_037", 128, 64 );
-			FadeBustshot( 9, FALSE, 0, 0, 0, 0, 1000, TRUE );
-			DrawBustshot(9, "scenario/shortcuts", 0, 0, 0, FALSE, 0, 0, 0, 0, 0, 0, 0, 20, 1000, TRUE );
-			Wait(10000);
-
-			DrawScene( "black", 1000 );
 
 			SetValidityOfSaving( TRUE );
 			CallSection("YoiDay1");
@@ -258,11 +233,6 @@ void main()
 		if (LoadValueFromLocalWork( LOCALWORK_NO_RESULT ) == 1) {
 			StopBGM( 2 );
 			PlaySE( 1, "wa_037", 128, 64 );
-			FadeBustshot( 9, FALSE, 0, 0, 0, 0, 1000, TRUE );
-			DrawBustshot(9, "scenario/shortcuts", 0, 0, 0, FALSE, 0, 0, 0, 0, 0, 0, 0, 20, 1000, TRUE );
-			Wait(10000);
-
-			DrawScene( "black", 1000 );
 
 			SetValidityOfSaving( TRUE );
 			CallSection("TokiDay1");
@@ -294,11 +264,6 @@ void main()
 		if (LoadValueFromLocalWork( LOCALWORK_NO_RESULT ) == 1) {
 			StopBGM( 2 );
 			PlaySE( 1, "wa_037", 128, 64 );
-			FadeBustshot( 9, FALSE, 0, 0, 0, 0, 1000, TRUE );
-			DrawBustshot(9, "scenario/shortcuts", 0, 0, 0, FALSE, 0, 0, 0, 0, 0, 0, 0, 20, 1000, TRUE );
-			Wait(10000);
-
-			DrawScene( "black", 1000 );
 
 			SetValidityOfSaving( TRUE );
 			CallSection("OmoteDay1");
@@ -330,11 +295,6 @@ void main()
 		if (LoadValueFromLocalWork( LOCALWORK_NO_RESULT ) == 1) {
 			StopBGM( 2 );
 			PlaySE( 1, "wa_037", 128, 64 );
-			FadeBustshot( 9, FALSE, 0, 0, 0, 0, 1000, TRUE );
-			DrawBustshot(9, "scenario/shortcuts", 0, 0, 0, FALSE, 0, 0, 0, 0, 0, 0, 0, 20, 1000, TRUE );
-			Wait(10000);
-
-			DrawScene( "black", 1000 );
 
 			SetValidityOfSaving( TRUE );
 			CallSection("PoliceCaseFiles");


### PR DESCRIPTION
This reflects a change we recently made in the main arcs. The shortcuts are now part of the UI mod:

![image](https://user-images.githubusercontent.com/539462/72013907-2149fb80-325f-11ea-913f-2e8e57095a02.png)
