### PR TITLE
Update kage_003.txt

### DIFF
--- a/Update/kage_003.txt
+++ b/Update/kage_003.txt
@@ -43,7 +43,7 @@ void main()
 //rぬるくなったコーヒーの残りを飲み干してから、向かいに座る南井警部は顔を上げて私を見つめる。
 	if (GetGlobalFlag(GADVMode)) { OutputLineAll("", NULL, Line_ContinueAfterTyping); }
 	OutputLine(NULL, "ぬるくなったコーヒーの残りを飲み干してから、向かいに座る南井警部は顔を, 私を見つめる。",
-			NULL, "After downing the remains of her now lukewarm coffee, Inspector Minai looks up at me from across the table.", Line_Normal);
+			NULL, "After downing the remains of her now lukewarm coffee, Chief Inspector Minai looks up at me from across the table.", Line_Normal);
 	ClearMessage();
 
 //r心なしか、眉間に皺が寄っているように、…いや、間違いなく寄っていたが、その理由が理解できる私はあえて見なかったことにした。
@@ -399,13 +399,13 @@ void main()
 //r私と大石さんはこの町ではいわば『異邦人』だ。
 	if (GetGlobalFlag(GADVMode)) { OutputLineAll("", NULL, Line_ContinueAfterTyping); }
 	OutputLine(NULL, "私と大石さんはこの町ではいわば『異邦人』だ。",
-			NULL, "Ooishi-san and I are essentially <i>foreigners</i> here.", Line_Normal);
+			NULL, "Ooishi-san and I are <i>outsiders</i>, you could say.", Line_Normal);
 	ClearMessage();
 
 //r実際に誰がどこにいて、何があるのかといったことは書類上のデータでしか把握していない弱みがあった。
 	if (GetGlobalFlag(GADVMode)) { OutputLineAll("", NULL, Line_ContinueAfterTyping); }
 	OutputLine(NULL, "実際に誰がどこにいて、何があるのかといったことは書類上のデータでしか把握していない弱みがあった。",
-			NULL, "In all actuality, we fell completely short on any of the particulars regarding this town. Our knowledge only extended as far as the data compiled in official documents, which didn't go beyond information such as where anyone lives or what was around the area.", Line_Normal);
+			NULL, "Thinking about it practically, gathering information on whoever lives in this town and what's around the area through data compiled in official documents alone, has its flaws.", Line_Normal);
 	ClearMessage();
 
 //赤坂rvS08/13/321000315.「私たちには残念ながら、土地勘がありません。kvS08/13/321000316.郷に入っては、のたとえではありませんが、その状態で見当もなく無闇に捜査を行っても、本来求めるべき正確な情報を掴むことは難しいでしょう」

--- a/Update/kage_003.txt
+++ b/Update/kage_003.txt
@@ -405,7 +405,7 @@ void main()
 //r実際に誰がどこにいて、何があるのかといったことは書類上のデータでしか把握していない弱みがあった。
 	if (GetGlobalFlag(GADVMode)) { OutputLineAll("", NULL, Line_ContinueAfterTyping); }
 	OutputLine(NULL, "実際に誰がどこにいて、何があるのかといったことは書類上のデータでしか把握していない弱みがあった。",
-			NULL, "A shortcoming of our investigation was that, all of the official documents on this town only have the most basic data, so all we have to work off of is who's where and what's there.", Line_Normal);
+			NULL, "In our preliminary research, the official documents we managed to find on this town only had the most basic of data, which could be boiled down to who's where and what's there. That's one of our biggest weaknesses.", Line_Normal);
 	ClearMessage();
 
 //赤坂rvS08/13/321000315.「私たちには残念ながら、土地勘がありません。kvS08/13/321000316.郷に入っては、のたとえではありませんが、その状態で見当もなく無闇に捜査を行っても、本来求めるべき正確な情報を掴むことは難しいでしょう」

--- a/Update/kage_003.txt
+++ b/Update/kage_003.txt
@@ -106,7 +106,7 @@ void main()
 			NULL, "\"But, why cross over to another prefecture entirely? Why Kakiuchi City?", Line_WaitForInput);
 	ModPlayVoiceLS(4, 28, "ps3/s08/28/320500230", 256, TRUE);
 	OutputLine(NULL, "　別に難癖を申し上げるつもりはありませんが、鹿骨市近隣の町村は他にもあったはずです」",
-			NULL, "Not to saying it was wrong of you to do so, but there must be a couple of places that are closer to Shishibone City.\"", Line_Normal);
+			NULL, "Not to say it was wrong of you to do so, but there must be a couple of places that are closer to Shishibone City.\"", Line_Normal);
 	ClearMessage();
 
 	FadeBustshot( 3, FALSE, 0, 0, 0, 0, 200, TRUE );

--- a/Update/kage_003.txt
+++ b/Update/kage_003.txt
@@ -220,7 +220,7 @@ void main()
 	if (GetGlobalFlag(GADVMode)) { OutputLine("<color=#797d8a>赤坂</color>", NULL, "<color=#797d8a>Akasaka</color>", NULL, Line_ContinueAfterTyping); }
 	ModPlayVoiceLS(4, 13, "ps3/s08/13/321000307", 256, TRUE);
 	OutputLine(NULL, "「あ…そ、そうですね」",
-			NULL, "\"Oh... I-I see.\"", Line_Normal);
+			NULL, "\"Oh... r-right.\"", Line_Normal);
 	ClearMessage();
 
 	ModDrawCharacter(4, 28, "sprite/tomo1a_shian_", "0", -160, 0, 0, FALSE, 0, 0, 0, 0, 0, 0, 0, 19, 200, TRUE );
@@ -248,17 +248,17 @@ void main()
 //r少々、熱くなりすぎて話が脱線したと、私は咳払いして気を落ち着ける。
 	if (GetGlobalFlag(GADVMode)) { OutputLineAll("", NULL, Line_ContinueAfterTyping); }
 	OutputLine(NULL, "少々、熱くなりすぎて話が脱線したと、私は咳払いして気を落ち着ける。",
-			NULL, "Before I knew it, the conversation trailed off and the temperature started getting unreasonably warm, so I cleared my throat while trying to pull myself together.", Line_Normal);
+			NULL, "Before I knew it, the conversation trailed off and the temperature in the room started to feel unreasonably warm, so I cleared my throat while trying to pull myself together.", Line_Normal);
 	ClearMessage();
 
 //r南井警部の見解は保守的ではなく、もっともなことだ。この地域の刑事課に他県のガス災害、そして陰謀云々を語ったところで、職務としてできることは何もない。
 	if (GetGlobalFlag(GADVMode)) {
 		OutputLineAll("", NULL, Line_ContinueAfterTyping);
 		OutputLine(NULL, "南井警部の見解は保守的ではなく、もっともなことだ。この地域の刑事課に他県のガス災害、そして陰謀云々を語ったところで、職務としてできることは何もない。",
-				NULL, "<size=-2>Inspector Minai wasn't purposefully being dismissive, her opinions are completely valid. Just because I discuss the possiblity of a conspiracy surrounding another town's gas disaster, doesn't mean that they have to follow up on it, especially when they don't even work in that prefecture.", Line_Normal);
+				NULL, "<size=-2>Inspector Minai wasn't purposefully being dismissive, her opinions are completely valid. Just because I discuss the possiblity of a conspiracy surrounding the gas disaster another town, doesn't mean that they have to follow up on it, especially when they don't even work in that prefecture.", Line_Normal);
 	} else {
 		OutputLine(NULL, "南井警部の見解は保守的ではなく、もっともなことだ。この地域の刑事課に他県のガス災害、そして陰謀云々を語ったところで、職務としてできることは何もない。",
-				NULL, "Inspector Minai wasn't purposefully being dismissive, her opinions are completely valid. Just because I discuss the possiblity of a conspiracy surrounding another town's gas disaster, doesn't mean that they have to follow up on it, especially when they don't even work in that prefecture.", Line_Normal);
+				NULL, "Inspector Minai wasn't purposefully being dismissive, her opinions are completely valid. Just because I discuss the possiblity of a conspiracy surrounding the gas disaster another town, doesn't mean that they have to follow up on it, especially when they don't even work in that prefecture", Line_Normal);
 	}
 	ClearMessage();
 
@@ -390,7 +390,7 @@ void main()
 	if (GetGlobalFlag(GADVMode)) { OutputLine("<color=#797d8a>赤坂</color>", NULL, "<color=#797d8a>Akasaka</color>", NULL, Line_ContinueAfterTyping); }
 	ModPlayVoiceLS(4, 13, "ps3/s08/13/321000313", 256, TRUE);
 	OutputLine(NULL, "「そう言ってもらえると助かります。",
-			NULL, "\"I'm glad to hear you say that, your assitance would be .", Line_WaitForInput);
+			NULL, "\"I'm glad to hear you say that, your assitance would save us a lot of trouble.", Line_WaitForInput);
 	ModPlayVoiceLS(4, 13, "ps3/s08/13/321000314", 256, TRUE);
 	OutputLine(NULL, "それに…」",
 			NULL, "Besides...\"", Line_Normal);
@@ -405,17 +405,17 @@ void main()
 //r実際に誰がどこにいて、何があるのかといったことは書類上のデータでしか把握していない弱みがあった。
 	if (GetGlobalFlag(GADVMode)) { OutputLineAll("", NULL, Line_ContinueAfterTyping); }
 	OutputLine(NULL, "実際に誰がどこにいて、何があるのかといったことは書類上のデータでしか把握していない弱みがあった。",
-			NULL, "One shortcoming of our investigation was that, no matter where we went, if we asked people general questions, all we'd get was basic information we could've found on our own through official documents.", Line_Normal);
+			NULL, "A shortcoming of our investigation was that, all of the official documents on this town only have the most basic data, so all we have to work off of is who's where and what's there.", Line_Normal);
 	ClearMessage();
 
 //赤坂rvS08/13/321000315.「私たちには残念ながら、土地勘がありません。kvS08/13/321000316.郷に入っては、のたとえではありませんが、その状態で見当もなく無闇に捜査を行っても、本来求めるべき正確な情報を掴むことは難しいでしょう」
 	if (GetGlobalFlag(GADVMode)) { OutputLine("<color=#797d8a>赤坂</color>", NULL, "<color=#797d8a>Akasaka</color>", NULL, Line_ContinueAfterTyping); }
 	ModPlayVoiceLS(4, 13, "ps3/s08/13/321000315", 256, TRUE);
 	OutputLine(NULL, "「私たちには残念ながら、土地勘がありません。",
-			NULL, "\"Unfortunately, we aren't too familiar with this area.", Line_WaitForInput);
+			NULL, "\"We aren't too familiar with this area, unfortunately.", Line_WaitForInput);
 	ModPlayVoiceLS(4, 13, "ps3/s08/13/321000316", 256, TRUE);
 	OutputLine(NULL, "郷に入っては、のたとえではありませんが、その状態で見当もなく無闇に捜査を行っても、本来求めるべき正確な情報を掴むことは難しいでしょう」",
-			NULL, "We're heading into uncharted waters here, so if we recklessly started investigating as we are now, I'm sure we wouldn't be able to get the information we need no matter how good we are at our jobs.\"", Line_Normal);
+			NULL, "We're heading into uncharted waters here, so if we recklessly started investigating as we are now, I'm sure we wouldn't be able to get the information we need no matter how good we might be at our jobs.\"", Line_Normal);
 	ClearMessage();
 
 	ModDrawCharacter(4, 28, "sprite/tomo1a_def_", "0", -160, 0, 0, FALSE, 0, 0, 0, 0, 0, 0, 0, 19, 200, TRUE );

--- a/Update/kage_003.txt
+++ b/Update/kage_003.txt
@@ -179,7 +179,7 @@ void main()
 	if (GetGlobalFlag(GADVMode)) { OutputLine("<color=#797d8a>赤坂</color>", NULL, "<color=#797d8a>Akasaka</color>", NULL, Line_ContinueAfterTyping); }
 	ModPlayVoiceLS(4, 13, "ps3/s08/13/321000305", 256, TRUE);
 	OutputLine(NULL, "「だとすれば、いずれこの町にもその影響が及んで、捜査がやりにくくなるかもしれない。",
-			NULL, "\"If that happens to be true, it's only a matter of time before misinformation spreads to this city, and complicates our investigation even further.", Line_WaitForInput);
+			NULL, "\"If that happens to be true, it's only a matter of time before misinformation spreads to this city and complicates our investigation even further.", Line_WaitForInput);
 	ModPlayVoiceLS(4, 13, "ps3/s08/13/321000306", 256, TRUE);
 	OutputLine(NULL, "ですから、一刻も早く…」",
 			NULL, " So, we'd like to get started as soon as possible...\"", Line_Normal);

--- a/Update/kage_003.txt
+++ b/Update/kage_003.txt
@@ -405,7 +405,7 @@ void main()
 //r実際に誰がどこにいて、何があるのかといったことは書類上のデータでしか把握していない弱みがあった。
 	if (GetGlobalFlag(GADVMode)) { OutputLineAll("", NULL, Line_ContinueAfterTyping); }
 	OutputLine(NULL, "実際に誰がどこにいて、何があるのかといったことは書類上のデータでしか把握していない弱みがあった。",
-			NULL, "Thinking about it practically, gathering information on whoever lives in this town and what's around the area through data compiled in official documents alone, has its flaws.", Line_Normal);
+			NULL, "Gathering information on whoever lives in this town and what's around the area only through data compiled in official documents on its own has its setbacks.", Line_Normal);
 	ClearMessage();
 
 //赤坂rvS08/13/321000315.「私たちには残念ながら、土地勘がありません。kvS08/13/321000316.郷に入っては、のたとえではありませんが、その状態で見当もなく無闇に捜査を行っても、本来求めるべき正確な情報を掴むことは難しいでしょう」

--- a/Update/kage_003.txt
+++ b/Update/kage_003.txt
@@ -427,13 +427,13 @@ void main()
 			NULL, "\"That's true.", Line_WaitForInput);
 	ModPlayVoiceLS(4, 28, "ps3/s08/28/320500247", 256, TRUE);
 	OutputLine(NULL, "それにこの街の人はわりと淡白な傾向ですから、普通に聞き込みをしても有効な回答を得るのは結構、骨が折れると思います」",
-			NULL, "Trust me, I know the people in this town can be pretty frank about what they think, but if you don't know the right questions to ask they can be difficult enough to make you want to pull your hair out.\"", Line_Normal);
+			NULL, "Trust me, I know the people in this town tend to be indifferent about what happens around here, so if you don't ask the right questions, getting the information you want will be pretty much like pulling teeth.\"", Line_Normal);
 	ClearMessage();
 
 //r…かつての雛見沢のように排他的な結束がある場所の捜査は、聞き込みなどの情報収集において大きな障害がある。
 	if (GetGlobalFlag(GADVMode)) { OutputLineAll("", NULL, Line_ContinueAfterTyping); }
 	OutputLine(NULL, "…かつての雛見沢のように排他的な結束がある場所の捜査は、聞き込みなどの情報収集において大きな障害がある。",
-			NULL, "Investigating such a tightknit community as Hinamizawa is huge a problem for law enforcement. People are fiercely loyal to eachother above all, which serverely limits the amount of information we're able to gather there.", Line_Normal);
+			NULL, "Investigating such a tightknit community like Hinamizawa is huge a problem for law enforcement. People are fiercely loyal to each other above all, which serverely limits the amount of information we're able to gather there.", Line_Normal);
 	ClearMessage();
 
 //r逆に新興の市街によくある、隣人に無関心な雰囲気も警察にとっては厄介な場合が多い。

--- a/Update/kage_003.txt
+++ b/Update/kage_003.txt
@@ -365,7 +365,7 @@ void main()
 	if (GetGlobalFlag(GADVMode)) { OutputLine("<color=#9d7f69>巴</color>", NULL, "<color=#9d7f69>Tomoe</color>", NULL, Line_ContinueAfterTyping); }
 	ModPlayVoiceLS(4, 28, "ps3/s08/28/320500243", 256, TRUE);
 	OutputLine(NULL, "「…自分もあの事件には、どうにも引っかかるものを感じておりました」",
-			NULL, "\"...You know, that incident has been weighing on mind for some time now.\"", Line_Normal);
+			NULL, "\"...You know, that incident has been weighing on my mind for some time now.\"", Line_Normal);
 	ClearMessage();
 
 	ModDrawCharacter(4, 28, "sprite/tomo1a_shian_", "0", -160, 0, 0, FALSE, 0, 0, 0, 0, 0, 0, 0, 19, 200, TRUE );

--- a/Update/kage_003.txt
+++ b/Update/kage_003.txt
@@ -445,7 +445,7 @@ void main()
 //r各人から集めた情報が非常に曖昧で、正確性に欠けるものとなる場合が多いからだ。
 	if (GetGlobalFlag(GADVMode)) { OutputLineAll("", NULL, Line_ContinueAfterTyping); }
 	OutputLine(NULL, "各人から集めた情報が非常に曖昧で、正確性に欠けるものとなる場合が多いからだ。",
-			NULL, "There's been plenty of times where information gained from each witness can be very ambiguous, and in some cases even inaccurate.", Line_Normal);
+			NULL, "There are been plenty of times where information gained from each witness is very ambiguous, and in some cases even inaccurate.", Line_Normal);
 	ClearMessage();
 
 //赤坂rvS08/13/321000317.「…あと、よそ者の刑事が好き勝手に捜査を行えば、そちらの刑事課さんにとっても色々と問題があるかと思います」

--- a/Update/kage_003.txt
+++ b/Update/kage_003.txt
@@ -412,7 +412,7 @@ void main()
 	if (GetGlobalFlag(GADVMode)) { OutputLine("<color=#797d8a>赤坂</color>", NULL, "<color=#797d8a>Akasaka</color>", NULL, Line_ContinueAfterTyping); }
 	ModPlayVoiceLS(4, 13, "ps3/s08/13/321000315", 256, TRUE);
 	OutputLine(NULL, "「私たちには残念ながら、土地勘がありません。",
-			NULL, "\"... we aren't too familiar with this area, unfortunately.", Line_WaitForInput);
+			NULL, "\"...We aren't too familiar with this area, unfortunately.", Line_WaitForInput);
 	ModPlayVoiceLS(4, 13, "ps3/s08/13/321000316", 256, TRUE);
 	OutputLine(NULL, "郷に入っては、のたとえではありませんが、その状態で見当もなく無闇に捜査を行っても、本来求めるべき正確な情報を掴むことは難しいでしょう」",
 			NULL, "We're heading into uncharted waters here, so if we recklessly started investigating as we are now, I'm sure we wouldn't be able to get the information we need no matter how good we might be at our jobs.\"", Line_Normal);

--- a/Update/kage_003.txt
+++ b/Update/kage_003.txt
@@ -255,7 +255,7 @@ void main()
 	if (GetGlobalFlag(GADVMode)) {
 		OutputLineAll("", NULL, Line_ContinueAfterTyping);
 		OutputLine(NULL, "南井警部の見解は保守的ではなく、もっともなことだ。この地域の刑事課に他県のガス災害、そして陰謀云々を語ったところで、職務としてできることは何もない。",
-				NULL, "<size=-2>Inspector Minai wasn't purposefully being dismissive, her opinions are completely valid. Just because I discuss the possiblity of a conspiracy surrounding the gas disaster in another town doesn't mean that they have to follow up on it, especially when they don't even work in that prefecture.", Line_Normal);
+				NULL, "<size=-2>Chief Inspector Minai wasn't purposefully being dismissive, her opinions are completely valid. Just because I discuss the possibility of a conspiracy surrounding the gas disaster in another town doesn't mean that they have to follow up on it, especially when they don't even work in that prefecture.", Line_Normal);
 	} else {
 		OutputLine(NULL, "南井警部の見解は保守的ではなく、もっともなことだ。この地域の刑事課に他県のガス災害、そして陰謀云々を語ったところで、職務としてできることは何もない。",
 				NULL, "Inspector Minai wasn't purposefully being dismissive, her opinions are completely valid. Just because I discuss the possiblity of a conspiracy surrounding the gas disaster in another town doesn't mean that they have to follow up on it, especially when they don't even work in that prefecture.", Line_Normal);

--- a/Update/kage_003.txt
+++ b/Update/kage_003.txt
@@ -200,7 +200,7 @@ void main()
 //r南井警部は戸惑ったように小首を傾げながら、慎重に前置きして言った。
 	if (GetGlobalFlag(GADVMode)) { OutputLineAll("", NULL, Line_ContinueAfterTyping); }
 	OutputLine(NULL, "南井警部は戸惑ったように小首を傾げながら、慎重に前置きして言った。",
-			NULL, "With a tilt of her head, Inspector Minai carefully ponders her words before speaking again.", Line_Normal);
+			NULL, "With a tilt of her head, Chief Inspector Minai carefully pondered her words before speaking again.", Line_Normal);
 	ClearMessage();
 
 	ModDrawCharacter(4, 28, "sprite/tomo1a_huan_", "0", -160, 0, 0, FALSE, 0, 0, 0, 0, 0, 0, 0, 19, 200, TRUE );

--- a/Update/kage_003.txt
+++ b/Update/kage_003.txt
@@ -405,7 +405,7 @@ void main()
 //r実際に誰がどこにいて、何があるのかといったことは書類上のデータでしか把握していない弱みがあった。
 	if (GetGlobalFlag(GADVMode)) { OutputLineAll("", NULL, Line_ContinueAfterTyping); }
 	OutputLine(NULL, "実際に誰がどこにいて、何があるのかといったことは書類上のデータでしか把握していない弱みがあった。",
-			NULL, "Gathering information on whoever lives in this town and what's around the area only through data compiled in official documents on its own has its setbacks.", Line_Normal);
+			NULL, "Gathering information on whoever lives in this town and what's around the area just based on data compiled in official documents has its setbacks.", Line_Normal);
 	ClearMessage();
 
 //赤坂rvS08/13/321000315.「私たちには残念ながら、土地勘がありません。kvS08/13/321000316.郷に入っては、のたとえではありませんが、その状態で見当もなく無闇に捜査を行っても、本来求めるべき正確な情報を掴むことは難しいでしょう」

--- a/Update/kage_003.txt
+++ b/Update/kage_003.txt
@@ -42,8 +42,8 @@ void main()
 
 //rぬるくなったコーヒーの残りを飲み干してから、向かいに座る南井警部は顔を上げて私を見つめる。
 	if (GetGlobalFlag(GADVMode)) { OutputLineAll("", NULL, Line_ContinueAfterTyping); }
-	OutputLine(NULL, "ぬるくなったコーヒーの残りを飲み干してから、向かいに座る南井警部は顔を上げて私を見つめる。",
-			NULL, "Chief Inspector Minai was sitting across from me, and as soon as she finished drinking her iced coffee she looked up at me.", Line_Normal);
+	OutputLine(NULL, "ぬるくなったコーヒーの残りを飲み干してから、向かいに座る南井警部は顔を, 私を見つめる。",
+			NULL, "After downing the remains of her now lukewarm coffee, Inspector Minai looks up at me from across the table.", Line_Normal);
 	ClearMessage();
 
 //r心なしか、眉間に皺が寄っているように、…いや、間違いなく寄っていたが、その理由が理解できる私はあえて見なかったことにした。
@@ -60,7 +60,7 @@ void main()
 	if (GetGlobalFlag(GADVMode)) { OutputLine("<color=#797d8a>赤坂</color>", NULL, "<color=#797d8a>Akasaka</color>", NULL, Line_ContinueAfterTyping); }
 	ModPlayVoiceLS(4, 13, "ps3/s08/13/321000300", 256, TRUE);
 	OutputLine(NULL, "本来なら、一番近隣にあたる興宮から捜査を行うのがベストなんですが、現状では…」",
-			NULL, "Originally, the best course of action would have been to conduct the investigation from the nearest neighboring town of Okinomiya. But, given the present situation...\"", Line_Normal);
+			NULL, "Originally, the best course of action would have been to conduct the investigation from the nearest neighboring town of Okinomiya. But, given the circumstances...\"", Line_Normal);
 	ClearMessage();
 
 	DrawScene("black", 1000 );
@@ -68,7 +68,7 @@ void main()
 //r…大石さんと再会してから数日間、私は彼とともに興宮を訪れて調査活動を行った。
 	if (GetGlobalFlag(GADVMode)) { OutputLineAll("", NULL, Line_ContinueAfterTyping); }
 	OutputLine(NULL, "…大石さんと再会してから数日間、私は彼とともに興宮を訪れて調査活動を行った。",
-			NULL, "...A couple days after I reunited with Ooishi-san, we began our investigation by traveling to Okinomiya together.", Line_Normal);
+			NULL, "...A couple days after Ooishi-san and I met up, we visited Okinomiya in order to conduct our investigation.", Line_Normal);
 	ClearMessage();
 
 	DrawFilm( 2, 255, 225, 195, 255, 0, 500, TRUE );
@@ -77,13 +77,13 @@ void main()
 //rしかし、残念ながら興宮は災害による混乱が依然として続いており、そのためまともな情報が得られるどころか、『こんな状況下で！』と猛烈な反発を受けただけだった。
 	if (GetGlobalFlag(GADVMode)) { OutputLineAll("", NULL, Line_ContinueAfterTyping); }
 	OutputLine(NULL, "しかし、残念ながら興宮は災害による混乱が依然として続いており、そのためまともな情報が得られるどころか、『こんな状況下で！』と猛烈な反発を受けただけだった。",
-			NULL, "Unfortunately, Okinomiya was still in a state of chaos thanks to the disaster, so it was impossible for us to obtain any meaningful information. The \"extenuating circumstances\" pushed us away.", Line_Normal);
+			NULL, "Unfortunately, Okinomiya was still in a state of disarray in the wake of the disaster, so it was impossible for us to obtain any accurate information, much less anything related to our investigation. Conversely, all we received was ardent opposition from those we questioned.", Line_Normal);
 	ClearMessage();
 
 //rまた、災害救助に当たる各スタッフからも邪魔者扱いを受けて、活動は難航。
 	if (GetGlobalFlag(GADVMode)) { OutputLineAll("", NULL, Line_ContinueAfterTyping); }
 	OutputLine(NULL, "また、災害救助に当たる各スタッフからも邪魔者扱いを受けて、活動は難航。",
-			NULL, "Plus, all the staff members in the area were so focused on the disaster relief efforts that they only saw our investigation as a bother, which made things difficult.", Line_Normal);
+			NULL, "Not only was it the locals, but all of the disaster relief workers we encountered treated us with disdain, which further complicated our efforts.", Line_Normal);
 	ClearMessage();
 
 	DrawScene("background/neki1", 1000 );
@@ -91,7 +91,7 @@ void main()
 //rそこで私は大石さんとも相談した上で、調査範囲をこの垣内市へと変えることにしたのだ——。
 	if (GetGlobalFlag(GADVMode)) { OutputLineAll("", NULL, Line_ContinueAfterTyping); }
 	OutputLine(NULL, "そこで私は大石さんとも相談した上で、調査範囲をこの垣内市へと変えることにしたのだ——。",
-			NULL, "So, after consulting with Ooishi-san, we decided to change the scope of the investigation to Kakiuchi City.", Line_Normal);
+			NULL, "So, after consulting with Ooishi-san, we decided to refocus our efforts onto Kakiuchi City.", Line_Normal);
 	ClearMessage();
 
 	DrawSceneWithMask("white", "c", 0, 0, 1000 );
@@ -103,10 +103,10 @@ void main()
 	if (GetGlobalFlag(GADVMode)) { OutputLine("<color=#9d7f69>巴</color>", NULL, "<color=#9d7f69>Tomoe</color>", NULL, Line_ContinueAfterTyping); }
 	ModPlayVoiceLS(4, 28, "ps3/s08/28/320500229", 256, TRUE);
 	OutputLine(NULL, "「しかし、どうして県境を越えて、この垣内市を？",
-			NULL, "\"But, why cross the prefectural border into Kakiuchi City?", Line_WaitForInput);
+			NULL, "\"But, why cross over to another prefecture entirely? Why Kakiuchi City?", Line_WaitForInput);
 	ModPlayVoiceLS(4, 28, "ps3/s08/28/320500230", 256, TRUE);
 	OutputLine(NULL, "　別に難癖を申し上げるつもりはありませんが、鹿骨市近隣の町村は他にもあったはずです」",
-			NULL, " I'm not sending you away, but there should be other towns and villages closer to Shishibone City.\"", Line_Normal);
+			NULL, "Not to saying it was wrong of you to do so, but there must be a couple of places that are closer to Shishibone City.\"", Line_Normal);
 	ClearMessage();
 
 	FadeBustshot( 3, FALSE, 0, 0, 0, 0, 200, TRUE );
@@ -121,7 +121,7 @@ void main()
 			NULL, "\"Yeah, there were plenty.", Line_WaitForInput);
 	ModPlayVoiceLS(4, 11, "ps3/s08/11/321100223", 256, TRUE);
 	OutputLine(NULL, "ただ、その中でも垣内市は、５年前のダム建設騒動以来雛見沢から転居してくるご家族が他と比べても一番多かったんですよ」",
-			NULL, " But since the dam conflict five years ago, more families have moved from Hinamizawa to Kakiuchi City than any other city.\"", Line_Normal);
+			NULL, " But due to the dam conflict five years ago, more families from Hinamizawa have moved to Kakiuchi than to any other city.\"", Line_Normal);
 	ClearMessage();
 
 	ModDrawCharacter(3, 11, "sprite/oisi1_1_", "0", 160, 0, 0, FALSE, 0, 0, 0, 0, 0, 0, 0, 20, 200, TRUE );
@@ -130,7 +130,7 @@ void main()
 	if (GetGlobalFlag(GADVMode)) { OutputLine("<color=#a59da9>大石</color>", NULL, "<color=#a59da9>Ooishi</color>", NULL, Line_ContinueAfterTyping); }
 	ModPlayVoiceLS(4, 11, "ps3/s08/11/321100224", 256, TRUE);
 	OutputLine(NULL, "「しかも、この町は見たところ、他県だけあって例の大災害に対する関心が全体的に低い感じがします」",
-			NULL, "\"Plus, this town seems less impacted by the disaster than the others.\"", Line_Normal);
+			NULL, "\"Not just that, but that city seems to have suffered less from the disaster compared to other places we considered.\"", Line_Normal);
 	ClearMessage();
 
 	ModDrawCharacter(4, 28, "sprite/tomo1a_kanashimi_", "0", -160, 0, 0, FALSE, 0, 0, 0, 0, 0, 0, 0, 19, 200, TRUE );
@@ -139,24 +139,24 @@ void main()
 	if (GetGlobalFlag(GADVMode)) { OutputLine("<color=#9d7f69>巴</color>", NULL, "<color=#9d7f69>Tomoe</color>", NULL, Line_ContinueAfterTyping); }
 	ModPlayVoiceLS(4, 28, "ps3/s08/28/320500231", 256, TRUE);
 	OutputLine(NULL, "「それが、どういう…？」",
-			NULL, "\"What does that mean...?\"", Line_Normal);
+			NULL, "\"What do you mean by that?\"", Line_Normal);
 	ClearMessage();
 
 //赤坂rvS08/13/321000301.「つまりですね。kvS08/13/321000302.この町のように安定した都市部に住んでいる人たちなら、他と比べても理性的な応対が望めるかと考えたのです」
 	if (GetGlobalFlag(GADVMode)) { OutputLine("<color=#797d8a>赤坂</color>", NULL, "<color=#797d8a>Akasaka</color>", NULL, Line_ContinueAfterTyping); }
 	ModPlayVoiceLS(4, 13, "ps3/s08/13/321000301", 256, TRUE);
 	OutputLine(NULL, "「つまりですね。",
-			NULL, "\"In other words,", Line_WaitForInput);
+			NULL, "\"What I mean is,", Line_WaitForInput);
 	ModPlayVoiceLS(4, 13, "ps3/s08/13/321000302", 256, TRUE);
 	OutputLine(NULL, "この町のように安定した都市部に住んでいる人たちなら、他と比べても理性的な応対が望めるかと考えたのです」",
-			NULL, " we hope that the people living in a stable urban area like this will provide a more reasonable response than the others.\"", Line_Normal);
+			NULL, " these people are living in a much more stable environment, so they'll likely be easier to work with than people from towns closer to the disaster.\"", Line_Normal);
 	ClearMessage();
 
 //赤坂rvS08/13/321000303.「『祟り』に対する畏怖心が強いと、どうしても情報提供に二の足を踏んでしまいますからね」
 	if (GetGlobalFlag(GADVMode)) { OutputLine("<color=#797d8a>赤坂</color>", NULL, "<color=#797d8a>Akasaka</color>", NULL, Line_ContinueAfterTyping); }
 	ModPlayVoiceLS(4, 13, "ps3/s08/13/321000303", 256, TRUE);
 	OutputLine(NULL, "「『祟り』に対する畏怖心が強いと、どうしても情報提供に二の足を踏んでしまいますからね」",
-			NULL, "\"People who fear the \"curse\" are far less likely to provide meaningful information.\"", Line_Normal);
+			NULL, "\"People with a strong fear for the \"curse\" are far less likely to cooporate with our investigation.\"", Line_Normal);
 	ClearMessage();
 
 	ModDrawCharacter(4, 28, "sprite/tomo1a_shian_", "0", -160, 0, 0, FALSE, 0, 0, 0, 0, 0, 0, 0, 19, 200, TRUE );
@@ -165,21 +165,21 @@ void main()
 	if (GetGlobalFlag(GADVMode)) { OutputLine("<color=#9d7f69>巴</color>", NULL, "<color=#9d7f69>Tomoe</color>", NULL, Line_ContinueAfterTyping); }
 	ModPlayVoiceLS(4, 28, "ps3/s08/28/320500232", 256, TRUE);
 	OutputLine(NULL, "「…はぁ、そういうものなんですか」",
-			NULL, "\"...Huh, that's really such an issue?\"", Line_Normal);
+			NULL, "\"Huh, so that's how it is...\"", Line_Normal);
 	ClearMessage();
 
 //赤坂rvS08/13/321000304.「それにもしも、この災害の背後で組織だった政治的陰謀が本当に動いているとすれば、厳重な情報封鎖とかん口令が敷かれている可能性があります」
 	if (GetGlobalFlag(GADVMode)) { OutputLine("<color=#797d8a>赤坂</color>", NULL, "<color=#797d8a>Akasaka</color>", NULL, Line_ContinueAfterTyping); }
 	ModPlayVoiceLS(4, 13, "ps3/s08/13/321000304", 256, TRUE);
 	OutputLine(NULL, "「それにもしも、この災害の背後で組織だった政治的陰謀が本当に動いているとすれば、厳重な情報封鎖とかん口令が敷かれている可能性があります」",
-			NULL, "\"Besides, if the disaster was actually organized as part of a political conspiracy, there is a possibility that they've already laid the groundwork for a strict information blockade.\"", Line_Normal);
+			NULL, "\"Besides, if this disaster was actually part of a greater political conspiracy, there's always the chance that they've already taken control of the narrative and placed a gag rule on anyone who may know valuable information.\"", Line_Normal);
 	ClearMessage();
 
 //赤坂rvS08/13/321000305.「だとすれば、いずれこの町にもその影響が及んで、捜査がやりにくくなるかもしれない。kvS08/13/321000306.ですから、一刻も早く…」
 	if (GetGlobalFlag(GADVMode)) { OutputLine("<color=#797d8a>赤坂</color>", NULL, "<color=#797d8a>Akasaka</color>", NULL, Line_ContinueAfterTyping); }
 	ModPlayVoiceLS(4, 13, "ps3/s08/13/321000305", 256, TRUE);
 	OutputLine(NULL, "「だとすれば、いずれこの町にもその影響が及んで、捜査がやりにくくなるかもしれない。",
-			NULL, "\"If so, it may even reach as far as this town, which could complicate the investigation even further.", Line_WaitForInput);
+			NULL, "\"If that happens to be true, it's only a matter of time before misinformation spreads to this city, and complicates our investigation even further.", Line_WaitForInput);
 	ModPlayVoiceLS(4, 13, "ps3/s08/13/321000306", 256, TRUE);
 	OutputLine(NULL, "ですから、一刻も早く…」",
 			NULL, " So, we'd like to get started as soon as possible...\"", Line_Normal);
@@ -191,16 +191,16 @@ void main()
 	if (GetGlobalFlag(GADVMode)) { OutputLine("<color=#9d7f69>巴</color>", NULL, "<color=#9d7f69>Tomoe</color>", NULL, Line_ContinueAfterTyping); }
 	ModPlayVoiceLS(4, 28, "ps3/s08/28/320500233", 256, TRUE);
 	OutputLine(NULL, "「えっと、…あの、すみません。",
-			NULL, "\"Umm... Oh, sorry.", Line_WaitForInput);
+			NULL, "\"Umm... I'm sorry.", Line_WaitForInput);
 	ModPlayVoiceLS(4, 28, "ps3/s08/28/320500234", 256, TRUE);
 	OutputLine(NULL, "お気を悪くされるかもしれませんが…」",
-			NULL, " This must be such a bother...\"", Line_Normal);
+			NULL, "Please don't take this the wrong way...\"", Line_Normal);
 	ClearMessage();
 
 //r南井警部は戸惑ったように小首を傾げながら、慎重に前置きして言った。
 	if (GetGlobalFlag(GADVMode)) { OutputLineAll("", NULL, Line_ContinueAfterTyping); }
 	OutputLine(NULL, "南井警部は戸惑ったように小首を傾げながら、慎重に前置きして言った。",
-			NULL, "Chief Inspector Minai slightly tilted her head to the side with a puzzled look on her face, then leaned forward and spoke.", Line_Normal);
+			NULL, "With a tilt of her head, Inspector Minai carefully ponders her words before speaking again.", Line_Normal);
 	ClearMessage();
 
 	ModDrawCharacter(4, 28, "sprite/tomo1a_huan_", "0", -160, 0, 0, FALSE, 0, 0, 0, 0, 0, 0, 0, 19, 200, TRUE );
@@ -209,18 +209,18 @@ void main()
 	if (GetGlobalFlag(GADVMode)) { OutputLine("<color=#9d7f69>巴</color>", NULL, "<color=#9d7f69>Tomoe</color>", NULL, Line_ContinueAfterTyping); }
 	ModPlayVoiceLS(4, 28, "ps3/s08/28/320500235", 256, TRUE);
 	OutputLine(NULL, "「自分は刑事課の人間なので、公安の方の、特に政治レベルの捜査をお手伝いするのは筋が違うかと思います。",
-			NULL, "\"I'm a member of the criminal investigation division, so it's a little different from public safety, especially when it comes to assisting politically motivated investigations. ", GetGlobalFlag(GLinemodeSp));
+			NULL, "\"I'm a member of the criminal investigations unit, so I don't think I'm qualified to speak on matters of public safety, much less know anything about how to go about investigating political conspiracies. ", GetGlobalFlag(GLinemodeSp));
 	if (GetGlobalFlag(GADVMode)) { OutputLine("<color=#9d7f69>巴</color>", NULL, "<color=#9d7f69>Tomoe</color>", NULL, Line_ContinueAfterTyping); }
 	ModPlayVoiceLS(4, 28, "ps3/s08/28/320500236", 256, TRUE);
 	OutputLine(NULL, "そもそも話が大きすぎて、いきなり理解するのはいささか…」",
-			NULL, "Plus, this story seems so huge, I'm hardly able to grasp the whole picture...\"", Line_Normal);
+			NULL, "Even if I did, this story seems so wild that I have a hard time keeping up with what you're saying...\"", Line_Normal);
 	ClearMessage();
 
 //赤坂rvS08/13/321000307.「あ…そ、そうですね」
 	if (GetGlobalFlag(GADVMode)) { OutputLine("<color=#797d8a>赤坂</color>", NULL, "<color=#797d8a>Akasaka</color>", NULL, Line_ContinueAfterTyping); }
 	ModPlayVoiceLS(4, 13, "ps3/s08/13/321000307", 256, TRUE);
 	OutputLine(NULL, "「あ…そ、そうですね」",
-			NULL, "\"Oh... t-that's true.\"", Line_Normal);
+			NULL, "\"Oh... I-I see.\"", Line_Normal);
 	ClearMessage();
 
 	ModDrawCharacter(4, 28, "sprite/tomo1a_shian_", "0", -160, 0, 0, FALSE, 0, 0, 0, 0, 0, 0, 0, 19, 200, TRUE );
@@ -229,43 +229,43 @@ void main()
 	if (GetGlobalFlag(GADVMode)) { OutputLine("<color=#9d7f69>巴</color>", NULL, "<color=#9d7f69>Tomoe</color>", NULL, Line_ContinueAfterTyping); }
 	ModPlayVoiceLS(4, 28, "ps3/s08/28/320500237", 256, TRUE);
 	OutputLine(NULL, "「それに、自分の職務は犯罪事件を捜査することであって、犯罪自体の存在の有無を確かめることではありません。",
-			NULL, "\"Besides, my job is to investigate crimes, not confirm the existence of a crime itself.", Line_WaitForInput);
+			NULL, "\"Besides, as part of the criminal investigations unit, my job's to investigate criminal offenses, not figure out whether a crime happened in the first place.", Line_WaitForInput);
 	ModPlayVoiceLS(4, 28, "ps3/s08/28/320500238", 256, TRUE);
 	OutputLine(NULL, "その点は、どうかご理解ください」",
-			NULL, " So, please understand that point.\"", Line_Normal);
+			NULL, " So, please keep that in mind.\"", Line_Normal);
 	ClearMessage();
 
 //赤坂rvS08/13/321000308.「…失礼しました。kvS08/13/321000309.つい、気持ちが急いてしまって」
 	if (GetGlobalFlag(GADVMode)) { OutputLine("<color=#797d8a>赤坂</color>", NULL, "<color=#797d8a>Akasaka</color>", NULL, Line_ContinueAfterTyping); }
 	ModPlayVoiceLS(4, 13, "ps3/s08/13/321000308", 256, TRUE);
 	OutputLine(NULL, "「…失礼しました。",
-			NULL, "\"...I'm terribly sorry.", Line_WaitForInput);
+			NULL, "\"...I'm sorry for bringing this up then.", Line_WaitForInput);
 	ModPlayVoiceLS(4, 13, "ps3/s08/13/321000309", 256, TRUE);
 	OutputLine(NULL, "つい、気持ちが急いてしまって」",
-			NULL, " I let my emotions run out of control.\"", Line_Normal);
+			NULL, " Seems like I let my feelings get the best of me here.\"", Line_Normal);
 	ClearMessage();
 
 //r少々、熱くなりすぎて話が脱線したと、私は咳払いして気を落ち着ける。
 	if (GetGlobalFlag(GADVMode)) { OutputLineAll("", NULL, Line_ContinueAfterTyping); }
 	OutputLine(NULL, "少々、熱くなりすぎて話が脱線したと、私は咳払いして気を落ち着ける。",
-			NULL, "It started to get hot as the conversation derailed, so I cleared my throat to calm myself down.", Line_Normal);
+			NULL, "Before I knew it, the conversation trailed off and the temperature started getting unreasonably warm, so I cleared my throat while trying to pull myself together.", Line_Normal);
 	ClearMessage();
 
 //r南井警部の見解は保守的ではなく、もっともなことだ。この地域の刑事課に他県のガス災害、そして陰謀云々を語ったところで、職務としてできることは何もない。
 	if (GetGlobalFlag(GADVMode)) {
 		OutputLineAll("", NULL, Line_ContinueAfterTyping);
 		OutputLine(NULL, "南井警部の見解は保守的ではなく、もっともなことだ。この地域の刑事課に他県のガス災害、そして陰謀云々を語ったところで、職務としてできることは何もない。",
-				NULL, "<size=-2>Chief Inspector Minai wasn't being conservative, her views were absolutely valid. Even though I informed the criminal investigators in this area about the conspiracies related to the gas disaster, it's not their duty to act on that information.", Line_Normal);
+				NULL, "<size=-2>Inspector Minai wasn't purposefully being dismissive, her opinions are completely valid. Just because I discuss the possiblity of a conspiracy surrounding another town's gas disaster, doesn't mean that they have to follow up on it, especially when they don't even work in that prefecture.", Line_Normal);
 	} else {
 		OutputLine(NULL, "南井警部の見解は保守的ではなく、もっともなことだ。この地域の刑事課に他県のガス災害、そして陰謀云々を語ったところで、職務としてできることは何もない。",
-				NULL, "Chief Inspector Minai wasn't being conservative. Her views were absolutely valid. Even though I informed the criminal investigators in this area about the conspiracies related to the gas disaster, it's not their duty to act on that information.", Line_Normal);
+				NULL, "Inspector Minai wasn't purposefully being dismissive, her opinions are completely valid. Just because I discuss the possiblity of a conspiracy surrounding another town's gas disaster, doesn't mean that they have to follow up on it, especially when they don't even work in that prefecture.", Line_Normal);
 	}
 	ClearMessage();
 
 //r私たちが彼女にお願いしたいことは、もっと別のことだった。
 	if (GetGlobalFlag(GADVMode)) { OutputLineAll("", NULL, Line_ContinueAfterTyping); }
 	OutputLine(NULL, "私たちが彼女にお願いしたいことは、もっと別のことだった。",
-			NULL, "But we had something different that we wanted to ask of her.", Line_Normal);
+			NULL, "But there was still something we wanted to ask, something we needed from her.", Line_Normal);
 	ClearMessage();
 
 	ModDrawCharacter(3, 11, "sprite/oisi1_4_", "0", 160, 0, 0, FALSE, 0, 0, 0, 0, 0, 0, 0, 20, 200, TRUE );
@@ -298,7 +298,7 @@ void main()
 	if (GetGlobalFlag(GADVMode)) { OutputLine("<color=#a59da9>大石</color>", NULL, "<color=#a59da9>Ooishi</color>", NULL, Line_ContinueAfterTyping); }
 	ModPlayVoiceLS(4, 11, "ps3/s08/11/321100227", 256, TRUE);
 	OutputLine(NULL, "「今回の一件は、それとも大きく関わっているんですよ」",
-			NULL, "\"It's heavily involved with this current case.\"", Line_Normal);
+			NULL, "\"It's heavily related to this current case.\"", Line_Normal);
 	ClearMessage();
 
 	ModDrawCharacter(3, 11, "sprite/oisi1_5_", "0", 160, 0, 0, FALSE, 0, 0, 0, 0, 0, 0, 0, 20, 200, TRUE );
@@ -314,7 +314,7 @@ void main()
 	if (GetGlobalFlag(GADVMode)) { OutputLine("<color=#a59da9>大石</color>", NULL, "<color=#a59da9>Ooishi</color>", NULL, Line_ContinueAfterTyping); }
 	ModPlayVoiceLS(4, 11, "ps3/s08/11/321100229", 256, TRUE);
 	OutputLine(NULL, "「…そして、あの祟りの数日後に大災害が起こって、村人全員が亡くなった」",
-			NULL, "\"...And then a few days after the curse, a massive disaster took place that destroyed the entire village.\"", Line_Normal);
+			NULL, "\"...And if so, that means that a few days after the "curse", a massive disaster took place that killed everyone in that village.\"", Line_Normal);
 	ClearMessage();
 
 	ModDrawCharacter(4, 28, "sprite/tomo1a_huan_", "0", -160, 0, 0, FALSE, 0, 0, 0, 0, 0, 0, 0, 19, 200, TRUE );
@@ -330,7 +330,7 @@ void main()
 	if (GetGlobalFlag(GADVMode)) { OutputLine("<color=#797d8a>赤坂</color>", NULL, "<color=#797d8a>Akasaka</color>", NULL, Line_ContinueAfterTyping); }
 	ModPlayVoiceLS(4, 13, "ps3/s08/13/321000310", 256, TRUE);
 	OutputLine(NULL, "「警部が立ち会われた事件と、私たちが調べようとしている『オヤシロさまの祟り』による大災害。",
-			NULL, "\"That case, which you investigated on-site, and this catastrophic disaster may have both been caused by \"Oyashiro-sama's curse\" and that's what we're trying to figure out. ", GetGlobalFlag(GLinemodeSp));
+			NULL, "\"After considering everything we know, we believe that this catastrophic disaster, and the case of the burning curse you investigated, may have both been caused by \"Oyashiro-sama's curse\".", GetGlobalFlag(GLinemodeSp));
 	if (GetGlobalFlag(GADVMode)) { OutputLine("<color=#797d8a>赤坂</color>", NULL, "<color=#797d8a>Akasaka</color>", NULL, Line_ContinueAfterTyping); }
 	ModPlayVoiceLS(4, 13, "ps3/s08/13/321000311", 256, TRUE);
 	OutputLine(NULL, "…偶然にしては、時系列が並びすぎている」",
@@ -356,7 +356,7 @@ void main()
 //r南井警部は両手を組み、あごを埋めて考え込む。そして空になったカップを見つめながら、静かに切り出した。
 	if (GetGlobalFlag(GADVMode)) { OutputLineAll("", NULL, Line_ContinueAfterTyping); }
 	OutputLine(NULL, "南井警部は両手を組み、あごを埋めて考え込む。そして空になったカップを見つめながら、静かに切り出した。",
-			NULL, "Chief Inspector Minai folded her hands together and pressed them against her chin.", Line_Normal);
+			NULL, "Inspector Minai laced her fingers and pressed them against her chin in contemplation. Then, while gazing at her now empty cup of coffee, she breaks her silence.", Line_Normal);
 	ClearMessage();
 
 	ModDrawCharacter(4, 28, "sprite/tomo1a_shinken_", "2", -160, 0, 0, FALSE, 0, 0, 0, 0, 0, 0, 0, 19, 200, TRUE );
@@ -365,7 +365,7 @@ void main()
 	if (GetGlobalFlag(GADVMode)) { OutputLine("<color=#9d7f69>巴</color>", NULL, "<color=#9d7f69>Tomoe</color>", NULL, Line_ContinueAfterTyping); }
 	ModPlayVoiceLS(4, 28, "ps3/s08/28/320500243", 256, TRUE);
 	OutputLine(NULL, "「…自分もあの事件には、どうにも引っかかるものを感じておりました」",
-			NULL, "\"...I was feeling a little stuck on that incident, myself.\"", Line_Normal);
+			NULL, "\"...You know, that incident has been weighing on mind for some time now.\"", Line_Normal);
 	ClearMessage();
 
 	ModDrawCharacter(4, 28, "sprite/tomo1a_shian_", "0", -160, 0, 0, FALSE, 0, 0, 0, 0, 0, 0, 0, 19, 200, TRUE );
@@ -374,7 +374,7 @@ void main()
 	if (GetGlobalFlag(GADVMode)) { OutputLine("<color=#9d7f69>巴</color>", NULL, "<color=#9d7f69>Tomoe</color>", NULL, Line_ContinueAfterTyping); }
 	ModPlayVoiceLS(4, 28, "ps3/s08/28/320500244", 256, TRUE);
 	OutputLine(NULL, "「その背後にあるものが雛見沢村の祟りにまつわる可能性があるというのならば、その正体を暴くことは例の焼殺事件に関する手がかりになるかもしれない」",
-			NULL, "\"If there's a possibility that the force behind the curse in Hinamizawa is related to the burning case, uncovering the truth behind it could be a valuable clue.\"", Line_Normal);
+			NULL, "\"If the true culprit behind the curse in Hinamizawa is also involved the great disaster, then acertaining the truth behind everything you've told me should also provide valuble clues to solving the burned corpse incident.\"", Line_Normal);
 	ClearMessage();
 
 	ModDrawCharacter(4, 28, "sprite/tomo1a_warai_", "1", -160, 0, 0, FALSE, 0, 0, 0, 0, 0, 0, 0, 19, 200, TRUE );
@@ -383,17 +383,17 @@ void main()
 	if (GetGlobalFlag(GADVMode)) { OutputLine("<color=#9d7f69>巴</color>", NULL, "<color=#9d7f69>Tomoe</color>", NULL, Line_ContinueAfterTyping); }
 	ModPlayVoiceLS(4, 28, "ps3/s08/28/320500245", 256, TRUE);
 	OutputLine(NULL, "「その意味での共同捜査は、自分にとっても悪くないお話です」",
-			NULL, "\"So in that sense, a joint investigation wouldn't be an issue at all.\"", Line_Normal);
+			NULL, "\"When you put it that way, a joint investigation doesn't seem like a bad deal to me.\"", Line_Normal);
 	ClearMessage();
 
 //赤坂rvS08/13/321000313.「そう言ってもらえると助かります。kvS08/13/321000314.それに…」
 	if (GetGlobalFlag(GADVMode)) { OutputLine("<color=#797d8a>赤坂</color>", NULL, "<color=#797d8a>Akasaka</color>", NULL, Line_ContinueAfterTyping); }
 	ModPlayVoiceLS(4, 13, "ps3/s08/13/321000313", 256, TRUE);
 	OutputLine(NULL, "「そう言ってもらえると助かります。",
-			NULL, "\"It would be tremendously helpful if you agreed.", Line_WaitForInput);
+			NULL, "\"I'm glad to hear you say that, your assitance would be .", Line_WaitForInput);
 	ModPlayVoiceLS(4, 13, "ps3/s08/13/321000314", 256, TRUE);
 	OutputLine(NULL, "それに…」",
-			NULL, " Plus...\"", Line_Normal);
+			NULL, "Besides...\"", Line_Normal);
 	ClearMessage();
 
 //r私と大石さんはこの町ではいわば『異邦人』だ。
@@ -405,17 +405,17 @@ void main()
 //r実際に誰がどこにいて、何があるのかといったことは書類上のデータでしか把握していない弱みがあった。
 	if (GetGlobalFlag(GADVMode)) { OutputLineAll("", NULL, Line_ContinueAfterTyping); }
 	OutputLine(NULL, "実際に誰がどこにいて、何があるのかといったことは書類上のデータでしか把握していない弱みがあった。",
-			NULL, "One shortcoming of our investigation was that there could be intricacies of the investigation that only someone familiar with the area could fully grasp.", Line_Normal);
+			NULL, "One shortcoming of our investigation was that, no matter where we went, if we asked people general questions, all we'd get was basic information we could've found on our own through official documents.", Line_Normal);
 	ClearMessage();
 
 //赤坂rvS08/13/321000315.「私たちには残念ながら、土地勘がありません。kvS08/13/321000316.郷に入っては、のたとえではありませんが、その状態で見当もなく無闇に捜査を行っても、本来求めるべき正確な情報を掴むことは難しいでしょう」
 	if (GetGlobalFlag(GADVMode)) { OutputLine("<color=#797d8a>赤坂</color>", NULL, "<color=#797d8a>Akasaka</color>", NULL, Line_ContinueAfterTyping); }
 	ModPlayVoiceLS(4, 13, "ps3/s08/13/321000315", 256, TRUE);
 	OutputLine(NULL, "「私たちには残念ながら、土地勘がありません。",
-			NULL, "\"Unfortunately, we aren't acquainted with this area.", Line_WaitForInput);
+			NULL, "\"Unfortunately, we aren't too familiar with this area.", Line_WaitForInput);
 	ModPlayVoiceLS(4, 13, "ps3/s08/13/321000316", 256, TRUE);
 	OutputLine(NULL, "郷に入っては、のたとえではありませんが、その状態で見当もなく無闇に捜査を行っても、本来求めるべき正確な情報を掴むことは難しいでしょう」",
-			NULL, " We're entering unfamiliar territory, so if we carry on our investigation like this it will be difficult for us to grasp all the necessary information.\"", Line_Normal);
+			NULL, "We're heading into uncharted waters here, so if we recklessly started investigating as we are now, I'm sure we wouldn't be able to get the information we need no matter how good we are at our jobs.\"", Line_Normal);
 	ClearMessage();
 
 	ModDrawCharacter(4, 28, "sprite/tomo1a_def_", "0", -160, 0, 0, FALSE, 0, 0, 0, 0, 0, 0, 0, 19, 200, TRUE );
@@ -427,39 +427,39 @@ void main()
 			NULL, "\"That's true.", Line_WaitForInput);
 	ModPlayVoiceLS(4, 28, "ps3/s08/28/320500247", 256, TRUE);
 	OutputLine(NULL, "それにこの街の人はわりと淡白な傾向ですから、普通に聞き込みをしても有効な回答を得るのは結構、骨が折れると思います」",
-			NULL, " Besides, it can be difficult to get answers through normal questioning because the people in this city tend to be rather reserved.\"", Line_Normal);
+			NULL, "Trust me, I know the people in this town can be pretty frank about what they think, but if you don't know the right questions to ask they can be difficult enough to make you want to pull your hair out.\"", Line_Normal);
 	ClearMessage();
 
 //r…かつての雛見沢のように排他的な結束がある場所の捜査は、聞き込みなどの情報収集において大きな障害がある。
 	if (GetGlobalFlag(GADVMode)) { OutputLineAll("", NULL, Line_ContinueAfterTyping); }
 	OutputLine(NULL, "…かつての雛見沢のように排他的な結束がある場所の捜査は、聞き込みなどの情報収集において大きな障害がある。",
-			NULL, "...Investigating a place like Hinamizawa with a fiercely independent local identity can also be a major roadblock to information gathering.", Line_Normal);
+			NULL, "Investigating such a tightknit community as Hinamizawa is huge a problem for law enforcement. People are fiercely loyal to eachother above all, which serverely limits the amount of information we're able to gather there.", Line_Normal);
 	ClearMessage();
 
 //r逆に新興の市街によくある、隣人に無関心な雰囲気も警察にとっては厄介な場合が多い。
 	if (GetGlobalFlag(GADVMode)) { OutputLineAll("", NULL, Line_ContinueAfterTyping); }
 	OutputLine(NULL, "逆に新興の市街によくある、隣人に無関心な雰囲気も警察にとっては厄介な場合が多い。",
-			NULL, "However, the atmosphere in developing towns can also be troublesome for the police, as the people feel completely indifferent toward their neighbors.", Line_Normal);
+			NULL, "But on the other hand, the atmosphere in newly founded communities also has its own issues. When people feel completely indifferent toward their neighbors, they might not pay enough attention to even know any meaningful information in the first place.", Line_Normal);
 	ClearMessage();
 
 //r各人から集めた情報が非常に曖昧で、正確性に欠けるものとなる場合が多いからだ。
 	if (GetGlobalFlag(GADVMode)) { OutputLineAll("", NULL, Line_ContinueAfterTyping); }
 	OutputLine(NULL, "各人から集めた情報が非常に曖昧で、正確性に欠けるものとなる場合が多いからだ。",
-			NULL, "The information gained from each person can be very ambiguous, and in some cases even inaccurate.", Line_Normal);
+			NULL, "There's been plenty of times where information gained from each witness can be very ambiguous, and in some cases even inaccurate.", Line_Normal);
 	ClearMessage();
 
 //赤坂rvS08/13/321000317.「…あと、よそ者の刑事が好き勝手に捜査を行えば、そちらの刑事課さんにとっても色々と問題があるかと思います」
 	if (GetGlobalFlag(GADVMode)) { OutputLine("<color=#797d8a>赤坂</color>", NULL, "<color=#797d8a>Akasaka</color>", NULL, Line_ContinueAfterTyping); }
 	ModPlayVoiceLS(4, 13, "ps3/s08/13/321000317", 256, TRUE);
 	OutputLine(NULL, "「…あと、よそ者の刑事が好き勝手に捜査を行えば、そちらの刑事課さんにとっても色々と問題があるかと思います」",
-			NULL, "\"...And if we perform an arbitrary investigation as outsiders, it could pose problems for the local criminal investigation division as well.\"", Line_Normal);
+			NULL, "\"And if people think that we're just a couple of outside police officers sticking our nose into their business, it could pose problems for the local detectives as well.\"", Line_Normal);
 	ClearMessage();
 
 //赤坂rvS08/13/321000318.「ですからまずは警部にご了解と、できればご協力もお願いしたいと考えた次第なのです」
 	if (GetGlobalFlag(GADVMode)) { OutputLine("<color=#797d8a>赤坂</color>", NULL, "<color=#797d8a>Akasaka</color>", NULL, Line_ContinueAfterTyping); }
 	ModPlayVoiceLS(4, 13, "ps3/s08/13/321000318", 256, TRUE);
 	OutputLine(NULL, "「ですからまずは警部にご了解と、できればご協力もお願いしたいと考えた次第なのです」",
-			NULL, "\"So first and foremost, we would like to request your cooperation if at all possible, Chief Inspector.\"", Line_Normal);
+			NULL, "\"Therefore, if you're in agreement, we would like to formally request your cooperation if at all possible, Chief Inspector.\"", Line_Normal);
 	ClearMessage();
 
 	ModDrawCharacter(4, 28, "sprite/tomo1a_shian_", "0", -160, 0, 0, FALSE, 0, 0, 0, 0, 0, 0, 0, 19, 200, TRUE );
@@ -477,17 +477,17 @@ void main()
 	if (GetGlobalFlag(GADVMode)) { OutputLine("<color=#9d7f69>巴</color>", NULL, "<color=#9d7f69>Tomoe</color>", NULL, Line_ContinueAfterTyping); }
 	ModPlayVoiceLS(4, 28, "ps3/s08/28/320500249", 256, TRUE);
 	OutputLine(NULL, "「…うちも一課はともかく二課は口やかましい人が多いので、お二人の捜査に難癖をつけることがあるかもしれませんね。",
-			NULL, "\"...The First Division will support you, but there are plenty of troublemakers in the Second Division that could make your investigations difficult.", Line_WaitForInput);
+			NULL, "\"...The First Division and I will support you, but there are plenty of people in the Second Division that will find countless reasons to object to your investigation.", Line_WaitForInput);
 	ModPlayVoiceLS(4, 28, "ps3/s08/28/320500250", 256, TRUE);
 	OutputLine(NULL, "それについては、私のほうでなんとかします」",
-			NULL, " But as far as that's concerned, I'll deal with it somehow.\"", Line_Normal);
+			NULL, " But, you can leave all of them to me.\"", Line_Normal);
 	ClearMessage();
 
 //赤坂rvS08/13/321000319.「助かります」
 	if (GetGlobalFlag(GADVMode)) { OutputLine("<color=#797d8a>赤坂</color>", NULL, "<color=#797d8a>Akasaka</color>", NULL, Line_ContinueAfterTyping); }
 	ModPlayVoiceLS(4, 13, "ps3/s08/13/321000319", 256, TRUE);
 	OutputLine(NULL, "「助かります」",
-			NULL, "\"That would be wonderful.\"", Line_Normal);
+			NULL, "\"We're in your debt.\"", Line_Normal);
 	ClearMessage();
 
 	ModDrawCharacter(4, 28, "sprite/tomo1a_huan_", "0", -160, 0, 0, FALSE, 0, 0, 0, 0, 0, 0, 0, 19, 200, TRUE );
@@ -496,7 +496,7 @@ void main()
 	if (GetGlobalFlag(GADVMode)) { OutputLine("<color=#9d7f69>巴</color>", NULL, "<color=#9d7f69>Tomoe</color>", NULL, Line_ContinueAfterTyping); }
 	ModPlayVoiceLS(4, 28, "ps3/s08/28/320500251", 256, TRUE);
 	OutputLine(NULL, "「…とは言っても、例の事件はお隣の県警さんの管轄ですから」",
-			NULL, "\"...However, the case you were referring to is actually under the jurisdiction of the prefectural police next door.\"", Line_Normal);
+			NULL, "\"...However, the case you were referring to is actually under the jurisdiction of the neighboring prefecture's police.\"", Line_Normal);
 	ClearMessage();
 
 //巴rvS08/28/320500252.「署長黙認とはいえ自分のほうで越権行為を働いたことが後々問題になれば、逆に大石さんたちにもご迷惑をおかけするかもしれませんよ？」

--- a/Update/kage_003.txt
+++ b/Update/kage_003.txt
@@ -165,7 +165,7 @@ void main()
 	if (GetGlobalFlag(GADVMode)) { OutputLine("<color=#9d7f69>巴</color>", NULL, "<color=#9d7f69>Tomoe</color>", NULL, Line_ContinueAfterTyping); }
 	ModPlayVoiceLS(4, 28, "ps3/s08/28/320500232", 256, TRUE);
 	OutputLine(NULL, "「…はぁ、そういうものなんですか」",
-			NULL, "\"Huh, so that's how it is...\"", Line_Normal);
+			NULL, "\"Huh, so that's how it is...?\"", Line_Normal);
 	ClearMessage();
 
 //赤坂rvS08/13/321000304.「それにもしも、この災害の背後で組織だった政治的陰謀が本当に動いているとすれば、厳重な情報封鎖とかん口令が敷かれている可能性があります」

--- a/Update/kage_003.txt
+++ b/Update/kage_003.txt
@@ -258,7 +258,7 @@ void main()
 				NULL, "<size=-2>Chief Inspector Minai wasn't purposefully being dismissive, her opinions are completely valid. Just because I discuss the possibility of a conspiracy surrounding the gas disaster in another town doesn't mean that they have to follow up on it, especially when they don't even work in that prefecture.", Line_Normal);
 	} else {
 		OutputLine(NULL, "南井警部の見解は保守的ではなく、もっともなことだ。この地域の刑事課に他県のガス災害、そして陰謀云々を語ったところで、職務としてできることは何もない。",
-				NULL, "Inspector Minai wasn't purposefully being dismissive, her opinions are completely valid. Just because I discuss the possiblity of a conspiracy surrounding the gas disaster in another town doesn't mean that they have to follow up on it, especially when they don't even work in that prefecture.", Line_Normal);
+				NULL, "Chief Inspector Minai wasn't purposefully being dismissive, her opinions are completely valid. Just because I discuss the possibility of a conspiracy surrounding the gas disaster in another town doesn't mean that they have to follow up on it, especially when they don't even work in that prefecture.", Line_Normal);
 	}
 	ClearMessage();
 

--- a/Update/kage_003.txt
+++ b/Update/kage_003.txt
@@ -83,7 +83,7 @@ void main()
 //rまた、災害救助に当たる各スタッフからも邪魔者扱いを受けて、活動は難航。
 	if (GetGlobalFlag(GADVMode)) { OutputLineAll("", NULL, Line_ContinueAfterTyping); }
 	OutputLine(NULL, "また、災害救助に当たる各スタッフからも邪魔者扱いを受けて、活動は難航。",
-			NULL, "Not only was it the locals, but all of the disaster relief workers we encountered treated us with disdain, which further complicated our efforts.", Line_Normal);
+			NULL, "Not only was it the locals, but all of the disaster relief workers we encountered treated us with disdain, which further complicated our work.", Line_Normal);
 	ClearMessage();
 
 	DrawScene("background/neki1", 1000 );
@@ -156,7 +156,7 @@ void main()
 	if (GetGlobalFlag(GADVMode)) { OutputLine("<color=#797d8a>赤坂</color>", NULL, "<color=#797d8a>Akasaka</color>", NULL, Line_ContinueAfterTyping); }
 	ModPlayVoiceLS(4, 13, "ps3/s08/13/321000303", 256, TRUE);
 	OutputLine(NULL, "「『祟り』に対する畏怖心が強いと、どうしても情報提供に二の足を踏んでしまいますからね」",
-			NULL, "\"People with a strong fear for the \"curse\" are far less likely to cooporate with our investigation.\"", Line_Normal);
+			NULL, "\"People with a strong fear of the \"curse\" are far less likely to cooporate with our investigation.\"", Line_Normal);
 	ClearMessage();
 
 	ModDrawCharacter(4, 28, "sprite/tomo1a_shian_", "0", -160, 0, 0, FALSE, 0, 0, 0, 0, 0, 0, 0, 19, 200, TRUE );
@@ -255,10 +255,10 @@ void main()
 	if (GetGlobalFlag(GADVMode)) {
 		OutputLineAll("", NULL, Line_ContinueAfterTyping);
 		OutputLine(NULL, "南井警部の見解は保守的ではなく、もっともなことだ。この地域の刑事課に他県のガス災害、そして陰謀云々を語ったところで、職務としてできることは何もない。",
-				NULL, "<size=-2>Inspector Minai wasn't purposefully being dismissive, her opinions are completely valid. Just because I discuss the possiblity of a conspiracy surrounding the gas disaster another town, doesn't mean that they have to follow up on it, especially when they don't even work in that prefecture.", Line_Normal);
+				NULL, "<size=-2>Inspector Minai wasn't purposefully being dismissive, her opinions are completely valid. Just because I discuss the possiblity of a conspiracy surrounding the gas disaster in another town doesn't mean that they have to follow up on it, especially when they don't even work in that prefecture.", Line_Normal);
 	} else {
 		OutputLine(NULL, "南井警部の見解は保守的ではなく、もっともなことだ。この地域の刑事課に他県のガス災害、そして陰謀云々を語ったところで、職務としてできることは何もない。",
-				NULL, "Inspector Minai wasn't purposefully being dismissive, her opinions are completely valid. Just because I discuss the possiblity of a conspiracy surrounding the gas disaster another town, doesn't mean that they have to follow up on it, especially when they don't even work in that prefecture", Line_Normal);
+				NULL, "Inspector Minai wasn't purposefully being dismissive, her opinions are completely valid. Just because I discuss the possiblity of a conspiracy surrounding the gas disaster in another town doesn't mean that they have to follow up on it, especially when they don't even work in that prefecture.", Line_Normal);
 	}
 	ClearMessage();
 
@@ -314,7 +314,7 @@ void main()
 	if (GetGlobalFlag(GADVMode)) { OutputLine("<color=#a59da9>大石</color>", NULL, "<color=#a59da9>Ooishi</color>", NULL, Line_ContinueAfterTyping); }
 	ModPlayVoiceLS(4, 11, "ps3/s08/11/321100229", 256, TRUE);
 	OutputLine(NULL, "「…そして、あの祟りの数日後に大災害が起こって、村人全員が亡くなった」",
-			NULL, "\"...And if so, that means that a few days after the "curse", a massive disaster took place that killed everyone in that village.\"", Line_Normal);
+			NULL, "\"...And if so, that means that a few days after the "curse" took place, a massive disaster took place that killed everyone in that village.\"", Line_Normal);
 	ClearMessage();
 
 	ModDrawCharacter(4, 28, "sprite/tomo1a_huan_", "0", -160, 0, 0, FALSE, 0, 0, 0, 0, 0, 0, 0, 19, 200, TRUE );
@@ -330,7 +330,7 @@ void main()
 	if (GetGlobalFlag(GADVMode)) { OutputLine("<color=#797d8a>赤坂</color>", NULL, "<color=#797d8a>Akasaka</color>", NULL, Line_ContinueAfterTyping); }
 	ModPlayVoiceLS(4, 13, "ps3/s08/13/321000310", 256, TRUE);
 	OutputLine(NULL, "「警部が立ち会われた事件と、私たちが調べようとしている『オヤシロさまの祟り』による大災害。",
-			NULL, "\"After considering everything we know, we believe that this catastrophic disaster, and the case of the burning curse you investigated, may have both been caused by \"Oyashiro-sama's curse\".", GetGlobalFlag(GLinemodeSp));
+			NULL, "\"After considering everything we know, we believe that this catastrophic disaster, and the case of the burning corpse you investigated, may have both been caused by \"Oyashiro-sama's curse\".", GetGlobalFlag(GLinemodeSp));
 	if (GetGlobalFlag(GADVMode)) { OutputLine("<color=#797d8a>赤坂</color>", NULL, "<color=#797d8a>Akasaka</color>", NULL, Line_ContinueAfterTyping); }
 	ModPlayVoiceLS(4, 13, "ps3/s08/13/321000311", 256, TRUE);
 	OutputLine(NULL, "…偶然にしては、時系列が並びすぎている」",
@@ -374,7 +374,7 @@ void main()
 	if (GetGlobalFlag(GADVMode)) { OutputLine("<color=#9d7f69>巴</color>", NULL, "<color=#9d7f69>Tomoe</color>", NULL, Line_ContinueAfterTyping); }
 	ModPlayVoiceLS(4, 28, "ps3/s08/28/320500244", 256, TRUE);
 	OutputLine(NULL, "「その背後にあるものが雛見沢村の祟りにまつわる可能性があるというのならば、その正体を暴くことは例の焼殺事件に関する手がかりになるかもしれない」",
-			NULL, "\"If the true culprit behind the curse in Hinamizawa is also involved the great disaster, then acertaining the truth behind everything you've told me should also provide valuble clues to solving the burned corpse incident.\"", Line_Normal);
+			NULL, "\"If the true culprit behind the curse in Hinamizawa is also involved in that great disaster, then acertaining the truth behind everything you've told me should also provide valuble clues to solving the burned corpse incident.\"", Line_Normal);
 	ClearMessage();
 
 	ModDrawCharacter(4, 28, "sprite/tomo1a_warai_", "1", -160, 0, 0, FALSE, 0, 0, 0, 0, 0, 0, 0, 19, 200, TRUE );
@@ -390,7 +390,7 @@ void main()
 	if (GetGlobalFlag(GADVMode)) { OutputLine("<color=#797d8a>赤坂</color>", NULL, "<color=#797d8a>Akasaka</color>", NULL, Line_ContinueAfterTyping); }
 	ModPlayVoiceLS(4, 13, "ps3/s08/13/321000313", 256, TRUE);
 	OutputLine(NULL, "「そう言ってもらえると助かります。",
-			NULL, "\"I'm glad to hear you say that, your assitance would save us a lot of trouble.", Line_WaitForInput);
+			NULL, "\"I'm glad to hear you say that. Your assistance would save us a lot of trouble.", Line_WaitForInput);
 	ModPlayVoiceLS(4, 13, "ps3/s08/13/321000314", 256, TRUE);
 	OutputLine(NULL, "それに…」",
 			NULL, "Besides...\"", Line_Normal);
@@ -399,20 +399,20 @@ void main()
 //r私と大石さんはこの町ではいわば『異邦人』だ。
 	if (GetGlobalFlag(GADVMode)) { OutputLineAll("", NULL, Line_ContinueAfterTyping); }
 	OutputLine(NULL, "私と大石さんはこの町ではいわば『異邦人』だ。",
-			NULL, "Ooishi-san and I were essentially <i>foreigners</i> in this town.", Line_Normal);
+			NULL, "Ooishi-san and I are essentially <i>foreigners</i> here.", Line_Normal);
 	ClearMessage();
 
 //r実際に誰がどこにいて、何があるのかといったことは書類上のデータでしか把握していない弱みがあった。
 	if (GetGlobalFlag(GADVMode)) { OutputLineAll("", NULL, Line_ContinueAfterTyping); }
 	OutputLine(NULL, "実際に誰がどこにいて、何があるのかといったことは書類上のデータでしか把握していない弱みがあった。",
-			NULL, "In our preliminary research, the official documents we managed to find on this town only had the most basic of data, which could be boiled down to who's where and what's there. That's one of our biggest weaknesses.", Line_Normal);
+			NULL, "In all actuality, we fell completely short on any of the particulars regarding this town. Our knowledge only extended as far as the data compiled in official documents, which didn't go beyond information such as where anyone lives or what was around the area.", Line_Normal);
 	ClearMessage();
 
 //赤坂rvS08/13/321000315.「私たちには残念ながら、土地勘がありません。kvS08/13/321000316.郷に入っては、のたとえではありませんが、その状態で見当もなく無闇に捜査を行っても、本来求めるべき正確な情報を掴むことは難しいでしょう」
 	if (GetGlobalFlag(GADVMode)) { OutputLine("<color=#797d8a>赤坂</color>", NULL, "<color=#797d8a>Akasaka</color>", NULL, Line_ContinueAfterTyping); }
 	ModPlayVoiceLS(4, 13, "ps3/s08/13/321000315", 256, TRUE);
 	OutputLine(NULL, "「私たちには残念ながら、土地勘がありません。",
-			NULL, "\"We aren't too familiar with this area, unfortunately.", Line_WaitForInput);
+			NULL, "\"... we aren't too familiar with this area, unfortunately.", Line_WaitForInput);
 	ModPlayVoiceLS(4, 13, "ps3/s08/13/321000316", 256, TRUE);
 	OutputLine(NULL, "郷に入っては、のたとえではありませんが、その状態で見当もなく無闇に捜査を行っても、本来求めるべき正確な情報を掴むことは難しいでしょう」",
 			NULL, "We're heading into uncharted waters here, so if we recklessly started investigating as we are now, I'm sure we wouldn't be able to get the information we need no matter how good we might be at our jobs.\"", Line_Normal);

--- a/Update/kage_003.txt
+++ b/Update/kage_003.txt
@@ -374,7 +374,7 @@ void main()
 	if (GetGlobalFlag(GADVMode)) { OutputLine("<color=#9d7f69>巴</color>", NULL, "<color=#9d7f69>Tomoe</color>", NULL, Line_ContinueAfterTyping); }
 	ModPlayVoiceLS(4, 28, "ps3/s08/28/320500244", 256, TRUE);
 	OutputLine(NULL, "「その背後にあるものが雛見沢村の祟りにまつわる可能性があるというのならば、その正体を暴くことは例の焼殺事件に関する手がかりになるかもしれない」",
-			NULL, "\"If the true culprit behind the curse in Hinamizawa is also involved in that great disaster, then acertaining the truth behind everything you've told me should also provide valuble clues to solving the burned corpse incident.\"", Line_Normal);
+			NULL, "\"If the true culprit behind the curse in Hinamizawa is also involved in that great disaster, then ascertaining the truth behind everything you've told me should also provide valuable clues to solving the burned corpse incident.\"", Line_Normal);
 	ClearMessage();
 
 	ModDrawCharacter(4, 28, "sprite/tomo1a_warai_", "1", -160, 0, 0, FALSE, 0, 0, 0, 0, 0, 0, 0, 19, 200, TRUE );

--- a/Update/kage_003.txt
+++ b/Update/kage_003.txt
@@ -314,7 +314,7 @@ void main()
 	if (GetGlobalFlag(GADVMode)) { OutputLine("<color=#a59da9>大石</color>", NULL, "<color=#a59da9>Ooishi</color>", NULL, Line_ContinueAfterTyping); }
 	ModPlayVoiceLS(4, 11, "ps3/s08/11/321100229", 256, TRUE);
 	OutputLine(NULL, "「…そして、あの祟りの数日後に大災害が起こって、村人全員が亡くなった」",
-			NULL, "\"...And if so, that means that a few days after the "curse" took place, a massive disaster took place that killed everyone in that village.\"", Line_Normal);
+			NULL, "\"...And if so, that means that a few days after the \"curse\" took place, a massive disaster occurred that killed everyone in that village.\"", Line_Normal);
 	ClearMessage();
 
 	ModDrawCharacter(4, 28, "sprite/tomo1a_huan_", "0", -160, 0, 0, FALSE, 0, 0, 0, 0, 0, 0, 0, 19, 200, TRUE );

--- a/Update/kage_003.txt
+++ b/Update/kage_003.txt
@@ -433,7 +433,7 @@ void main()
 //r…かつての雛見沢のように排他的な結束がある場所の捜査は、聞き込みなどの情報収集において大きな障害がある。
 	if (GetGlobalFlag(GADVMode)) { OutputLineAll("", NULL, Line_ContinueAfterTyping); }
 	OutputLine(NULL, "…かつての雛見沢のように排他的な結束がある場所の捜査は、聞き込みなどの情報収集において大きな障害がある。",
-			NULL, "Investigating such a tightknit community like Hinamizawa is huge a problem for law enforcement. People are fiercely loyal to each other above all, which serverely limits the amount of information we're able to gather there.", Line_Normal);
+			NULL, "Investigating such a tightknit community like Hinamizawa is huge a problem for law enforcement. People are fiercely loyal to each other above all, which severely limits the amount of information we're able to gather there.", Line_Normal);
 	ClearMessage();
 
 //r逆に新興の市街によくある、隣人に無関心な雰囲気も警察にとっては厄介な場合が多い。

--- a/Update/kage_003.txt
+++ b/Update/kage_003.txt
@@ -452,7 +452,7 @@ void main()
 	if (GetGlobalFlag(GADVMode)) { OutputLine("<color=#797d8a>赤坂</color>", NULL, "<color=#797d8a>Akasaka</color>", NULL, Line_ContinueAfterTyping); }
 	ModPlayVoiceLS(4, 13, "ps3/s08/13/321000317", 256, TRUE);
 	OutputLine(NULL, "「…あと、よそ者の刑事が好き勝手に捜査を行えば、そちらの刑事課さんにとっても色々と問題があるかと思います」",
-			NULL, "\"And if people think that we're just a couple of outside police officers sticking our nose into their business, it could pose problems for the local detectives as well.\"", Line_Normal);
+			NULL, "\"And if people think that we're just a couple of outside police officers sticking our noses into their business, it could pose problems for the local detectives as well.\"", Line_Normal);
 	ClearMessage();
 
 //赤坂rvS08/13/321000318.「ですからまずは警部にご了解と、できればご協力もお願いしたいと考えた次第なのです」

--- a/Update/kage_003.txt
+++ b/Update/kage_003.txt
@@ -356,7 +356,7 @@ void main()
 //r南井警部は両手を組み、あごを埋めて考え込む。そして空になったカップを見つめながら、静かに切り出した。
 	if (GetGlobalFlag(GADVMode)) { OutputLineAll("", NULL, Line_ContinueAfterTyping); }
 	OutputLine(NULL, "南井警部は両手を組み、あごを埋めて考え込む。そして空になったカップを見つめながら、静かに切り出した。",
-			NULL, "Inspector Minai laced her fingers and pressed them against her chin in contemplation. Then, while gazing at her now empty cup of coffee, she breaks her silence.", Line_Normal);
+			NULL, "Chief Inspector Minai laced her fingers and pressed them against her chin in contemplation. Then, while gazing at her now empty cup of coffee, she broke her silence.", Line_Normal);
 	ClearMessage();
 
 	ModDrawCharacter(4, 28, "sprite/tomo1a_shinken_", "2", -160, 0, 0, FALSE, 0, 0, 0, 0, 0, 0, 0, 19, 200, TRUE );

--- a/Update/kage_003.txt
+++ b/Update/kage_003.txt
@@ -229,7 +229,7 @@ void main()
 	if (GetGlobalFlag(GADVMode)) { OutputLine("<color=#9d7f69>巴</color>", NULL, "<color=#9d7f69>Tomoe</color>", NULL, Line_ContinueAfterTyping); }
 	ModPlayVoiceLS(4, 28, "ps3/s08/28/320500237", 256, TRUE);
 	OutputLine(NULL, "「それに、自分の職務は犯罪事件を捜査することであって、犯罪自体の存在の有無を確かめることではありません。",
-			NULL, "\"Besides, as part of the criminal investigations unit, my job's to investigate criminal offenses, not figure out whether a crime happened in the first place.", Line_WaitForInput);
+			NULL, "\"Besides, as part of the criminal investigations unit, my job is to investigate criminal offenses, not figure out whether a crime happened in the first place.", Line_WaitForInput);
 	ModPlayVoiceLS(4, 28, "ps3/s08/28/320500238", 256, TRUE);
 	OutputLine(NULL, "その点は、どうかご理解ください」",
 			NULL, " So, please keep that in mind.\"", Line_Normal);

--- a/Update/kage_003.txt
+++ b/Update/kage_003.txt
@@ -172,7 +172,7 @@ void main()
 	if (GetGlobalFlag(GADVMode)) { OutputLine("<color=#797d8a>赤坂</color>", NULL, "<color=#797d8a>Akasaka</color>", NULL, Line_ContinueAfterTyping); }
 	ModPlayVoiceLS(4, 13, "ps3/s08/13/321000304", 256, TRUE);
 	OutputLine(NULL, "「それにもしも、この災害の背後で組織だった政治的陰謀が本当に動いているとすれば、厳重な情報封鎖とかん口令が敷かれている可能性があります」",
-			NULL, "\"Besides, if this disaster was actually part of a greater political conspiracy, there's always the chance that they've already taken control of the narrative and placed a gag rule on anyone who may know valuable information.\"", Line_Normal);
+			NULL, "\"Besides, if this disaster was actually part of a greater political conspiracy, there's always the chance that they've already taken control of the narrative and placed a gag order on anyone who may know valuable information.\"", Line_Normal);
 	ClearMessage();
 
 //赤坂rvS08/13/321000305.「だとすれば、いずれこの町にもその影響が及んで、捜査がやりにくくなるかもしれない。kvS08/13/321000306.ですから、一刻も早く…」


### PR DESCRIPTION
Change "Chief Inspector Minai" for "Inspector Minai" for instances with 南井警部. 警部 (keibu) used to refer to just plain Inspector before there was a restructuring of the police force in Japan in 2013 (after console arcs released?) where it came to refer specifically to the Chief Inspector. So in this case, Minai is a lower rank than a "Chief Inspector". Unless there's further plot stuff I'm missing, in which case lmk!