### PR TITLE
Translation correction

### DIFF
--- a/Update/yoig_007b.txt
+++ b/Update/yoig_007b.txt
@@ -516,7 +516,7 @@ void main()
 //r武道館でコンサートを開いたら、とっておきの歌を歌って、それを私へのプロポーズにしたいとか…。
 	if (GetGlobalFlag(GADVMode)) { OutputLineAll("", NULL, Line_ContinueAfterTyping); }
 	OutputLine(NULL, "武道館でコンサートを開いたら、とっておきの歌を歌って、それを私へのプロポーズにしたいとか…。",
-			NULL, "I want to play a concert at the opening of a martial arts tournament, and propose to you right after finishing my best song...", Line_Normal);
+			NULL, "I want to play a concert at the Budokan, and propose to you right after finishing my best song...", Line_Normal);
 	ClearMessage();
 
 //r彼は、笑っちゃうくらいに子どもじみたことを、本気で考えていた。


### PR DESCRIPTION
Translation correction. (Budokan refers to the Nippon Budokan in Tokyo.)