### PR TITLE
Translation correction

### DIFF
--- a/Update/toki_tips_004.txt
+++ b/Update/toki_tips_004.txt
@@ -76,7 +76,7 @@ void main()
 //rその他：××××××の疑い、症状レベルは××。
 	if (GetGlobalFlag(GADVMode)) { OutputLineAll("", NULL, Line_ContinueAfterTyping); }
 	OutputLine(NULL, "その他：××××××の疑い、症状レベルは××。",
-			NULL, "Other: Suspected of XXXXXX, symptom level is XX.", Line_ContinueAfterTyping);
+			NULL, "Other: Suspected of XXXXXX XXXXXXXX, symptom level is XX.", Line_ContinueAfterTyping);
 	FadeOutBGM( 0, 200, FALSE  );
 	OutputLineAll(NULL, "", Line_Normal);
 	ClearMessage();


### PR DESCRIPTION
Believe that ×××××× is meant to be 雛見沢症候群 (Hinamizawa Syndrome), so altered number of X to match the English letters for Hinamizawa Syndrome. If this is incorrect, ignore this.