### PR TITLE
TL improvement

### DIFF
--- a/Update/omot_009_4.txt
+++ b/Update/omot_009_4.txt
@@ -112,7 +112,7 @@ void main()
 			NULL, "\"If Rina were to take the treasury funds and leave Okinomiya...", Line_WaitForInput);
 	ModPlayVoiceLS(4, 1, "ps3/s14/01/210100713", 256, TRUE);
 	OutputLine(NULL, "いや、落とし前つけられて消されても、収入源を失った鉄平は、即、路頭に迷う。",
-			NULL, " Rather, even if she were to be erased in compensation for that, Teppei's only source of income would disappear, and he'd immediately end up in the gutter.", GetGlobalFlag(GLinemodeSp));
+			NULL, " Rather, even if she were to be eliminated as payback for that, Teppei's only source of income would disappear, and he'd immediately end up in the gutter.", GetGlobalFlag(GLinemodeSp));
 	if (GetGlobalFlag(GADVMode)) { OutputLine("<color=#956f6e>圭一</color>", NULL, "<color=#956f6e>Keiichi</color>", NULL, Line_ContinueAfterTyping); }
 	ModPlayVoiceLS(4, 1, "ps3/s14/01/210100714", 256, TRUE);
 	OutputLine(NULL, "家賃だってすぐに払えなくなるし、生活にも困る」",


### PR DESCRIPTION
Fixing a lack of "落とし前つけられて消されても、" in TL.
There may be a better expression.