### PR TITLE
Translation

### DIFF
--- a/Update/koto_001.txt
+++ b/Update/koto_001.txt
@@ -207,7 +207,7 @@ void main()
 //鬼rvS16/00/VT4D_oni1001.（…さすがは、『bピュトゥス.<純血>』最強の監視者。kvS16/00/VT4D_oni1002.この程度では、倒せぬか…っ！）
 	PlaySE(4, "ps3/s16/00/vt4d_oni1001", 256, 64);
 	OutputLine(NULL, "（…さすがは、『純血(ピュトゥス)』最強の監視者。",
-			NULL, "(...I would expect nothing less of the strongest Putus Guardian.", Line_WaitForInput);
+			NULL, "(...I would expect nothing less of the strongest Putus Observer.", Line_WaitForInput);
 	PlaySE(4, "ps3/s16/00/vt4d_oni1002", 256, 64);
 	OutputLine(NULL, "この程度では、倒せぬか…っ！）",
 			NULL, " Of course this wouldn't be enough to defeat her...!)", Line_Normal);
@@ -395,7 +395,7 @@ void main()
 			NULL, "\"So this is...", Line_WaitForInput);
 	PlaySE(4, "ps3/s16/45/ds43070003", 256, 64);
 	OutputLine(NULL, "…奥の手か？」",
-			NULL, " the trump card you spoke of?\"", Line_Normal);
+			NULL, " your so-called trump card?\"", Line_Normal);
 	ClearMessage();
 
 //r炎の明かりに浮かびあがったその顔には苦痛の表情どころか、…感情がない。
@@ -429,7 +429,7 @@ void main()
 //羽入rvS16/45/DS43070004.「…かりにもリューン十八bハィ.<羽爵>のひとり、ジェダの家名を継ぐ我が身。kvS16/45/DS43070005.そなたら外道に落ちた者の小賢しき手にかかるほど、落ちぶれてはおらぬ」
 	PlaySE(4, "ps3/s16/45/ds43070004", 256, 64);
 	OutputLine(NULL, "「…かりにもリューン十八羽爵(ハィ)のひとり、ジェダの家名を継ぐ我が身。",
-			NULL, "\"...Perhaps my appearance betrays the fact, but I am the successor of the Jedha family name, one of the 18 Ryun Hais.", Line_WaitForInput);
+			NULL, "\"...Perhaps my appearance betrays the fact, but I am the successor of the Jedha family name, one of the 18 Ryuun Hais.", Line_WaitForInput);
 	PlaySE(4, "ps3/s16/45/ds43070005", 256, 64);
 	OutputLine(NULL, "そなたら外道に落ちた者の小賢しき手にかかるほど、落ちぶれてはおらぬ」",
 			NULL, "I am not so enfeebled as to be felled by shrewd tactics from fiends such as yourselves.\"", Line_Normal);
@@ -495,7 +495,7 @@ void main()
 			NULL, "\"A simultaneous attack, is it?", Line_WaitForInput);
 	PlaySE(4, "ps3/s16/45/ds43070009", 256, 64);
 	OutputLine(NULL, "…悪くない」",
-			NULL, "...Better than expected.\"", Line_Normal);
+			NULL, "...Not bad.\"", Line_Normal);
 	ClearMessage();
 
 //r数と勢いを駆って、相手の意表をつき、…裂帛の気合でもって反撃の隙すら与えず、猛攻をかける。
@@ -576,7 +576,7 @@ void main()
 //羽入rvS16/45/DS43070011.「…力の差を見抜けなくては、ただの蛮勇だ」
 	PlaySE(4, "ps3/s16/45/ds43070011", 256, 64);
 	OutputLine(NULL, "「…力の差を見抜けなくては、ただの蛮勇だ」",
-			NULL, "\"...Failing to perceive the difference in power makes you naught but brutes.\"", Line_Normal);
+			NULL, "\"...Failing to perceive the difference in power makes you nothing but brutes.\"", Line_Normal);
 	ClearMessage();
 
 //r…ジェダが繰り出した剣撃の動きは、目にも『映らなかった』。
@@ -836,7 +836,7 @@ void main()
 
 //rその呟きが『背後』から聞こえていたことを悟った瞬間、ぞっとするような悪寒に『首領』は振り返るよりも早くその場を蹴って、勢いよく横に身を投げ出す。
 	OutputLine(NULL, "その呟きが『背後』から聞こえていたことを悟った瞬間、ぞっとするような悪寒に『首領』は振り返るよりも早くその場を蹴って、勢いよく横に身を投げ出す。",
-			NULL, "", Line_Normal);
+			NULL, "The moment he realized that whisper had come from <i>behind</i> him, the \"chief\" was knocked aside faster than he could turn around in spine-tingling fear."", Line_Normal);
 	ClearMessage();
 
 	DrawScene("background/a/cutin4", 1000 );
@@ -845,18 +845,18 @@ void main()
 
 //r刹那、閃光が一条眩くきらめき、…数拍遅れて風を切り裂く音が、鼓膜を震わせる。
 	OutputLine(NULL, "刹那、閃光が一条眩くきらめき、…数拍遅れて風を切り裂く音が、鼓膜を震わせる。",
-			NULL, "", Line_Normal);
+			NULL, "A single flash of like shone at that moment... followed by an ear-splitting howl of wind after a pregnant pause.", Line_Normal);
 	ClearMessage();
 
 //rそして次の瞬間、…自身が先ほどまで立っていた場所の近くにあった大木が、鈍く重い響きをあげて横殴りに倒れていった。
 	OutputLine(NULL, "そして次の瞬間、…自身が先ほどまで立っていた場所の近くにあった大木が、鈍く重い響きをあげて横殴りに倒れていった。",
-			NULL, "", Line_Normal);
+			NULL, "And just a second later... a tree near where the \"chief\" had been standing fell to the ground with a thud.", Line_Normal);
 	ClearMessage();
 
 //鬼rvS16/00/VT4D_oni1009.（……ッッ？！）
 	PlaySE(4, "ps3/s16/00/vt4d_oni1009", 256, 64);
 	OutputLine(NULL, "（……ッッ？！）",
-			NULL, "", Line_Normal);
+			NULL, "(...?!)", Line_Normal);
 	ClearMessage();
 
 	DrawScene("background/so5_01", 1000 );
@@ -866,7 +866,7 @@ void main()
 //羽入rvS16/45/DS43070015.「さすが『bピュトゥス.<純血>』、かわされたのは久しぶりだ」
 	PlaySE(4, "ps3/s16/45/ds43070015", 256, 64);
 	OutputLine(NULL, "「さすが『純血(ピュトゥス)』、かわされたのは久しぶりだ」",
-			NULL, "", Line_Normal);
+			NULL, "\"Impressive, Putus. It's been a really long time since someone dodged me.\"", Line_Normal);
 	ClearMessage();
 
 	DrawBustshot( 4, "sprite/normal/oha3_akire_0", 0, 0, 0, FALSE, 0, 0, 0, 0, 0, 0, 0, 19, 200, TRUE );
@@ -874,12 +874,12 @@ void main()
 //羽入rvS16/45/DS43070016.「…初撃を、な」
 	PlaySE(4, "ps3/s16/45/ds43070016", 256, 64);
 	OutputLine(NULL, "「…初撃を、な」",
-			NULL, "", Line_Normal);
+			NULL, "\"...The first time, anyway.\"", Line_Normal);
 	ClearMessage();
 
 //rそう呟いて…ジェダが髪をかきあげると、同時に。
 	OutputLine(NULL, "そう呟いて…ジェダが髪をかきあげると、同時に。",
-			NULL, "", Line_Normal);
+			NULL, "Jedha flipped her hair back, and at the same time...", Line_Normal);
 	ClearMessage();
 
 	PlaySE(3, "thisikuki", 256, 64);
@@ -893,7 +893,7 @@ void main()
 //鬼rvS16/00/VT4D_oni1010.（ぐっ…？！　ぐがぁぁぁッッ！！）
 	PlaySE(4, "ps3/s16/00/vt4d_oni1010", 256, 64);
 	OutputLine(NULL, "（ぐっ…？！　ぐがぁぁぁッッ！！）",
-			NULL, "", Line_Normal);
+			NULL, "(Ghhh...?! Ghghaaaaaaaaagh!!)", Line_Normal);
 	ClearMessage();
 
 	PlaySE(3, "addse07", 256, 64);
@@ -902,56 +902,56 @@ void main()
 
 //r『首領』が右の肩口と左脚の付け根に灼熱のような鋭い痛みを感じた途端、…鮮血が勢いよく噴き出す。
 	OutputLine(NULL, "『首領』が右の肩口と左脚の付け根に灼熱のような鋭い痛みを感じた途端、…鮮血が勢いよく噴き出す。",
-			NULL, "", Line_Normal);
+			NULL, "The moment the \"chief\" felt a burning sharp pain run through his right shoulder and the base of his left leg... spurts of blood followed.", Line_Normal);
 	ClearMessage();
 
 //r…かわしたのは、最初の一撃だけだった。
 	OutputLine(NULL, "…かわしたのは、最初の一撃だけだった。",
-			NULL, "", Line_Normal);
+			NULL, "...He'd only dodged the first ", Line_Normal);
 	ClearMessage();
 
 //r『首領』が体勢を崩した隙を狙ってさらに二度、ジェダは斬りつけていたのだ…！
 	OutputLine(NULL, "『首領』が体勢を崩した隙を狙ってさらに二度、ジェダは斬りつけていたのだ…！",
-			NULL, "", Line_Normal);
+			NULL, "Jedha's plan had been to slash at him again once he broke his posture, exposing an opening!", Line_Normal);
 	ClearMessage();
 
 //rしかも…しかもっ！
 	OutputLine(NULL, "しかも…しかもっ！",
-			NULL, "", Line_Normal);
+			NULL, "And... And that wasn't all!", Line_Normal);
 	ClearMessage();
 
 //rその傷は狙ったように動脈を切り裂き、深手ではないはずなのにおびただしい流血を強いている…！
 	OutputLine(NULL, "その傷は狙ったように動脈を切り裂き、深手ではないはずなのにおびただしい流血を強いている…！",
-			NULL, "", Line_Normal);
+			NULL, "One of his arteries was severed as if that had been the target all along, gushing torrents of blood even though the wound shouldn't have been that deep...!", Line_Normal);
 	ClearMessage();
 
 //鬼rvS16/00/VT4D_oni1011.（太刀筋が…見えないっ？kvS16/00/VT4D_oni1012.　バカなっ！　同じ『bピュトゥス.<純血>』で、これほどの差が…ッ？！）
 	PlaySE(4, "ps3/s16/00/vt4d_oni1011", 256, 64);
 	OutputLine(NULL, "（太刀筋が…見えないっ？",
-			NULL, "", Line_WaitForInput);
+			NULL, "(I can't... perceive her swordwork?", Line_WaitForInput);
 	PlaySE(4, "ps3/s16/00/vt4d_oni1012", 256, 64);
 	OutputLine(NULL, "　バカなっ！　同じ『純血(ピュトゥス)』で、これほどの差が…ッ？！）",
-			NULL, "", Line_Normal);
+			NULL, " Impossible! We're both Putus, so how can there be such a vast difference between us...?!)", Line_Normal);
 	ClearMessage();
 
 //rあふれ出る流血と激痛すらも忘れて、『首領』は驚愕にうち震える。
 	OutputLine(NULL, "あふれ出る流血と激痛すらも忘れて、『首領』は驚愕にうち震える。",
-			NULL, "", Line_Normal);
+			NULL, "The \"chief\" trembled with shock, completely forgetting all the bleeding and immense pain.", Line_Normal);
 	ClearMessage();
 
 //r『首領』はジェダと同じく、立場の違いこそあれ同じリューンの血を引く者。…でありながら、これほどの差が厳然と存在している。
 	OutputLine(NULL, "『首領』はジェダと同じく、立場の違いこそあれ同じリューンの血を引く者。…でありながら、これほどの差が厳然と存在している。",
-			NULL, "", Line_Normal);
+			NULL, "Despite them being in different positions, he was a Ryuun just like Jedha... and yet their gap was deeply pronounced.", Line_Normal);
 	ClearMessage();
 
 //rたとえ最強であれ、疲れもあれば傷も負う。ゆえに計略をかけて体力を削ぎ、その直後に多勢でかかれば倒せるはず。
 	OutputLine(NULL, "たとえ最強であれ、疲れもあれば傷も負う。ゆえに計略をかけて体力を削ぎ、その直後に多勢でかかれば倒せるはず。",
-			NULL, "", Line_Normal);
+			NULL, "Even if she was the strongest, she could be hurt once she got tired. So he'd planned to whittle down her stamina and overwhelm her with numbers immediately afterwards.", Line_Normal);
 	ClearMessage();
 
 //rそんな己の目論見の甘さを、『首領』はようやく思い知った…！
 	OutputLine(NULL, "そんな己の目論見の甘さを、『首領』はようやく思い知った…！",
-			NULL, "", Line_Normal);
+			NULL, "Yet it was only now that the \"chief\" finally realized how naive his scheme had been...!", Line_Normal);
 	ClearMessage();
 
 	PlaySE(3, "daidageki", 256, 64);
@@ -962,22 +962,22 @@ void main()
 
 //rガッ、…ガァァアァァァッッ！！
 	OutputLine(NULL, "ガッ、…ガァァアァァァッッ！！",
-			NULL, "", Line_Normal);
+			NULL, "Gaaah... gaaaaaaaaaaaaaaaaaaaaaah!", Line_Normal);
 	ClearMessage();
 
 //r『首領』は焦燥と狼狽のあまり、腕を振り回して襲いかかる。
 	OutputLine(NULL, "『首領』は焦燥と狼狽のあまり、腕を振り回して襲いかかる。",
-			NULL, "", Line_Normal);
+			NULL, "The \"chief\" swung his arms wildly in excess irritation and panic.", Line_Normal);
 	ClearMessage();
 
 //r薙いだ閃撃は烈風となって、虚空を裂き。
 	OutputLine(NULL, "薙いだ閃撃は烈風となって、虚空を裂き。",
-			NULL, "", Line_Normal);
+			NULL, "Those cleaving flashes became gales that cut through thin air.", Line_Normal);
 	ClearMessage();
 
 //r振り下ろした殴撲は固土を抉って、深い爪痕を残す。
 	OutputLine(NULL, "振り下ろした殴撲は固土を抉って、深い爪痕を残す。",
-			NULL, "", Line_Normal);
+			NULL, "His blows gouged out the earth and left deep claw marks.", Line_Normal);
 	ClearMessage();
 
 	PlaySE(3, "furu", 256, 64);
@@ -990,63 +990,63 @@ void main()
 
 //rが、…当たらない。当たらないのだ。
 	OutputLine(NULL, "が、…当たらない。当たらないのだ。",
-			NULL, "", Line_Normal);
+			NULL, "But... he missed. He hit no one.", Line_Normal);
 	ClearMessage();
 
 //r渾身の力を込めた、必殺の攻撃が。
 	OutputLine(NULL, "渾身の力を込めた、必殺の攻撃が。",
-			NULL, "", Line_Normal);
+			NULL, "For his desperate attack that used all his might...", Line_Normal);
 	ClearMessage();
 
 //rこれまで、この村や周囲の集落でおびただしい死と恐怖をつくり出してきたはずの腕が、爪が、牙が。
 	OutputLine(NULL, "これまで、この村や周囲の集落でおびただしい死と恐怖をつくり出してきたはずの腕が、爪が、牙が。",
-			NULL, "", Line_Normal);
+			NULL, "...And his arms, claws, and fangs that had brought harrowing death and fear to this village and the surrounding settlements...", Line_Normal);
 	ClearMessage();
 
 //r…まったくの、無力。
 	OutputLine(NULL, "…まったくの、無力。",
-			NULL, "", Line_Normal);
+			NULL, "...were completely powerless.", Line_Normal);
 	ClearMessage();
 
 //rしかもその攻撃は、かわされたり、防がれたりしているものではない――！
 	OutputLine(NULL, "しかもその攻撃は、かわされたり、防がれたりしているものではない——！",
-			NULL, "", Line_Normal);
+			NULL, "What's more, his attacks weren't even dodged or parried...!", Line_Normal);
 	ClearMessage();
 
 //鬼rvS16/00/VT4D_oni1013.（なぜだ…なぜ、これが当たらぬッ！！）
 	PlaySE(4, "ps3/s16/00/vt4d_oni1013", 256, 64);
 	OutputLine(NULL, "（なぜだ…なぜ、これが当たらぬッ！！）",
-			NULL, "", Line_Normal);
+			NULL, "(Why... Why can't I hit her?!)", Line_Normal);
 	ClearMessage();
 
 //r『首領』が暴れ回り、血を吐かんばかりの咆哮を喉の奥から迸らせながら何度も激しく斬りつけても斬りつけても、…ジェダは幻像のように刃を通過してしまう。
 	OutputLine(NULL, "『首領』が暴れ回り、血を吐かんばかりの咆哮を喉の奥から迸らせながら何度も激しく斬りつけても斬りつけても、…ジェダは幻像のように刃を通過してしまう。",
-			NULL, "", Line_Normal);
+			NULL, "The \"chief\" went on a rampage, unleashing bloodcurling roars from the pit of his throat while slashing at Jedha over and over again... yet she passed throw his blows like they were mirages.", Line_Normal);
 	ClearMessage();
 
 //r足も。
 	OutputLine(NULL, "足も。",
-			NULL, "", Line_Normal);
+			NULL, "He couldn't even graze her.", Line_Normal);
 	ClearMessage();
 
 //r腕も。
 	OutputLine(NULL, "腕も。",
-			NULL, "", Line_Normal);
+			NULL, "Not her legs.", Line_Normal);
 	ClearMessage();
 
 //rもちろん、顔も。
 	OutputLine(NULL, "もちろん、顔も。",
-			NULL, "", Line_Normal);
+			NULL, "Not her arms.", Line_Normal);
 	ClearMessage();
 
 //rその、闇に舞う長髪や、動きにたわんだ外套さえ、かすらせることすらできないのだ。
 	OutputLine(NULL, "その、闇に舞う長髪や、動きにたわんだ外套さえ、かすらせることすらできないのだ。",
-			NULL, "", Line_Normal);
+			NULL, "And of course, not her face, hair dancing in the darkness, or even the cloak moving in tune with her.", Line_Normal);
 	ClearMessage();
 
 //rしかも、少しの隙を狙って繰り出されるジェダの斬撃はあやまたず四肢の肉を貫き、関節を砕き、神経を断ち切って徐々に動きを奪ってゆく…！
 	OutputLine(NULL, "しかも、少しの隙を狙って繰り出されるジェダの斬撃はあやまたず四肢の肉を貫き、関節を砕き、神経を断ち切って徐々に動きを奪ってゆく…！",
-			NULL, "", Line_Normal);
+			NULL, "Furthermore, Jedha slashed at every small opening he presented, piercing his limbs, breaking his joints, severing his nerves, and gradually taking away his movement...!", Line_Normal);
 	ClearMessage();
 
 	DrawScene("background/a/cutin6", 1000 );
@@ -1056,7 +1056,7 @@ void main()
 //羽入rvS16/45/DS43070017.「遅いな」
 	PlaySE(4, "ps3/s16/45/ds43070017", 256, 64);
 	OutputLine(NULL, "「遅いな」",
-			NULL, "", Line_Normal);
+			NULL, "\"Too slow."\", Line_Normal);
 	ClearMessage();
 
 	DrawScene("background/a/cutin5", 1000 );
@@ -1066,7 +1066,7 @@ void main()
 //羽入rvS16/45/DS43070018.「こっちだ」
 	PlaySE(4, "ps3/s16/45/ds43070018", 256, 64);
 	OutputLine(NULL, "「こっちだ」",
-			NULL, "", Line_Normal);
+			NULL, "\"Right here.\"", Line_Normal);
 	ClearMessage();
 
 	DrawScene("background/a/cutin3", 1000 );
@@ -1076,7 +1076,7 @@ void main()
 //羽入rvS16/45/DS43070019.「がら空きだな」
 	PlaySE(4, "ps3/s16/45/ds43070019", 256, 64);
 	OutputLine(NULL, "「がら空きだな」",
-			NULL, "", Line_Normal);
+			NULL, "\"You're wide open.\"", Line_Normal);
 	ClearMessage();
 
 	DrawScene("background/a/cutin4", 1000 );
@@ -1091,17 +1091,17 @@ void main()
 
 //rギャアァァアァッッッ！！
 	OutputLine(NULL, "ギャアァァアァッッッ！！",
-			NULL, "", Line_Normal);
+			NULL, "Gyaghhhhhhhhhhhhhhhhhh!", Line_Normal);
 	ClearMessage();
 
 //r…動きの速さ、ではない。
 	OutputLine(NULL, "…動きの速さ、ではない。",
-			NULL, "", Line_Normal);
+			NULL, "...It wasn't a matter of speed.", Line_Normal);
 	ClearMessage();
 
 //rもっと違う、…自分たちにすらない能力の『次元』の違いだった。
 	OutputLine(NULL, "もっと違う、…自分たちにすらない能力の『次元』の違いだった。",
-			NULL, "", Line_Normal);
+			NULL, "It was something more... a difference in <i>dimension</i> of an ability they didn't even possess.", Line_Normal);
 	ClearMessage();
 
 	PlaySE(3, "addse07", 256, 64);
@@ -1110,22 +1110,22 @@ void main()
 
 //rガァァアァァァッッ！！
 	OutputLine(NULL, "ガァァアァァァッッ！！",
-			NULL, "", Line_Normal);
+			NULL, "Gaaaaaaaaaaaaaaaaaaaaaghhhhhhhhhhhhhh!", Line_Normal);
 	ClearMessage();
 
 //rそして、脚の腱を両方とも斬られた『首領』は、ついに立つことすらままならずその場に膝をついてどう、と崩れ落ちる。
 	OutputLine(NULL, "そして、脚の腱を両方とも斬られた『首領』は、ついに立つことすらままならずその場に膝をついてどう、と崩れ落ちる。",
-			NULL, "", Line_Normal);
+			NULL, "Then, with the tendons in his legs sliced, the \"chief\" could finally stand no longer and crumbled to his knees.", Line_Normal);
 	ClearMessage();
 
 //rすでに、腕は振り回すどころか…上げることさえも、できない。
 	OutputLine(NULL, "すでに、腕は振り回すどころか…上げることさえも、できない。",
-			NULL, "", Line_Normal);
+			NULL, "He couldn't swing his arms anymore... least to say even raise them.", Line_Normal);
 	ClearMessage();
 
 //r…しかし、それほどに満身創痍の『首領』を至近距離から悠然と見下ろしながら、ジェダは今や真っ赤に染まりきった刀身を鼻先に突き出し、傲然と『…立て』と言い放った。
 	OutputLine(NULL, "…しかし、それほどに満身創痍の『首領』を至近距離から悠然と見下ろしながら、ジェダは今や真っ赤に染まりきった刀身を鼻先に突き出し、傲然と『…立て』と言い放った。",
-			NULL, "", Line_Normal);
+			NULL, "But Jedha just calmly looked down at his tattered body from up close, pointed her bloodstained sword at his nose, and arrogantly said \"get up.\" ", Line_Normal);
 	ClearMessage();
 
 	DrawScene("background/so5_01", 1000 );
@@ -1135,32 +1135,32 @@ void main()
 //羽入rvS16/45/DS43070020.「…どうした？　もう仕舞いなのか」
 	PlaySE(4, "ps3/s16/45/ds43070020", 256, 64);
 	OutputLine(NULL, "「…どうした？　もう仕舞いなのか」",
-			NULL, "", Line_Normal);
+			NULL, "\"What's wrong? That all you got?\"", Line_Normal);
 	ClearMessage();
 
 	PlaySE(3, "dsse140", 256, 64);
 
 //rグッ、グォォォッ…！
 	OutputLine(NULL, "グッ、グォォォッ…！",
-			NULL, "", Line_Normal);
+			NULL, "Ghhhh, ghhhhhhhhhhhh!", Line_Normal);
 	ClearMessage();
 
 //羽入rvS16/45/DS43070021.「その程度か。その程度なのか、お前は？kvS16/45/DS43070022.　…いや、そうではあるまい。kvS16/45/DS43070023.仮にもリューンの血を引き、『bピュトゥス.<純血>』を名乗るお前が多くの生命を犠牲にして得たものが、この程度であるはずがない」
 	PlaySE(4, "ps3/s16/45/ds43070021", 256, 64);
 	OutputLine(NULL, "「その程度か。その程度なのか、お前は？",
-			NULL, "", Line_WaitForInput);
+			NULL, "\"That's it? That's the best you can do?", Line_WaitForInput);
 	PlaySE(4, "ps3/s16/45/ds43070022", 256, 64);
 	OutputLine(NULL, "　…いや、そうではあるまい。",
-			NULL, "", Line_WaitForInput);
+			NULL, " ...No, I highly doubt it.", Line_WaitForInput);
 	PlaySE(4, "ps3/s16/45/ds43070023", 256, 64);
 	OutputLine(NULL, "仮にもリューンの血を引き、『純血(ピュトゥス)』を名乗るお前が多くの生命を犠牲にして得たものが、この程度であるはずがない」",
-			NULL, "", Line_Normal);
+			NULL, " This can't be all there is to the self-proclaimed Putus with Ryuun blood who sacrificed so many lives.\"", Line_Normal);
 	ClearMessage();
 
 //鬼rvS16/00/VT4D_oni1014.（ぐっ、ぐぅぅ…ッ！！）
 	PlaySE(4, "ps3/s16/00/vt4d_oni1014", 256, 64);
 	OutputLine(NULL, "（ぐっ、ぐぅぅ…ッ！！）",
-			NULL, "", Line_Normal);
+			NULL, "(Ghhhh, ghhhhhh...!)", Line_Normal);
 	ClearMessage();
 
 	DrawBustshot( 4, "sprite/normal/oha3_akire_0", 0, 0, 0, FALSE, 0, 0, 0, 0, 0, 0, 0, 19, 200, TRUE );
@@ -1168,16 +1168,16 @@ void main()
 //羽入rvS16/45/DS43070024.「さぁ。早くここで、お前の全力を見せるがいい。kvS16/45/DS43070025.…立て。そのために、お前の爪や牙は『折らずに』残してやったのだから――」
 	PlaySE(4, "ps3/s16/45/ds43070024", 256, 64);
 	OutputLine(NULL, "「さぁ。早くここで、お前の全力を見せるがいい。",
-			NULL, "", Line_WaitForInput);
+			NULL, "\"Now hurry up and show me your true power."", Line_WaitForInput);
 	PlaySE(4, "ps3/s16/45/ds43070025", 256, 64);
 	OutputLine(NULL, "…立て。そのために、お前の爪や牙は『折らずに』残してやったのだから——」",
-			NULL, "", Line_Normal);
+			NULL, " ...Get up. This is exactly why I left your claws and fangs <i>intact</i>.", Line_Normal);
 	ClearMessage();
 
 //鬼rvS16/00/VT4D_oni1015.（こ、こいつ…まだ、底があるのかッ？！）
 	PlaySE(4, "ps3/s16/00/vt4d_oni1015", 256, 64);
 	OutputLine(NULL, "（こ、こいつ…まだ、底があるのかッ？！）",
-			NULL, "", Line_Normal);
+			NULL, "(D-damn her... She still has strength to spare?!)", Line_Normal);
 	ClearMessage();
 
 	DrawBustshot( 4, "sprite/normal/oha3_def_0", 0, 0, 0, FALSE, 0, 0, 0, 0, 0, 0, 0, 19, 200, TRUE );
@@ -1185,10 +1185,10 @@ void main()
 //羽入rvS16/45/DS43070026.「リューンの法は、罪と罰に等価を求める。kvS16/45/DS43070027.…ゆえに、お前には義務がある」
 	PlaySE(4, "ps3/s16/45/ds43070026", 256, 64);
 	OutputLine(NULL, "「リューンの法は、罪と罰に等価を求める。",
-			NULL, "", Line_WaitForInput);
+			NULL, "\"Ryuun law demands that sins be met with punishment.", Line_WaitForInput);
 	PlaySE(4, "ps3/s16/45/ds43070027", 256, 64);
 	OutputLine(NULL, "…ゆえに、お前には義務がある」",
-			NULL, "", Line_Normal);
+			NULL, " ...Therefore, you have that obligation.\"", Line_Normal);
 	ClearMessage();
 
 	DrawBustshot( 4, "sprite/normal/oha3_shinken_0", 0, 0, 0, FALSE, 0, 0, 0, 0, 0, 0, 0, 19, 200, TRUE );
@@ -1196,16 +1196,16 @@ void main()
 //羽入rvS16/45/DS43070028.「これまでに狩ってきたあわれな人間たち、破滅へと導いていった同朋たちへの仕打ちと同じように、kvS16/45/DS43070029.私を存分に愉しませ、長き星霜のつかの間の慰めとして、その贄となる義務」
 	PlaySE(4, "ps3/s16/45/ds43070028", 256, 64);
 	OutputLine(NULL, "「これまでに狩ってきたあわれな人間たち、破滅へと導いていった同朋たちへの仕打ちと同じように、",
-			NULL, "", Line_WaitForInput);
+			NULL, "\"Much like the poor humans you've hunted and the brothers and sisters you've led to destruction,", Line_WaitForInput);
 	PlaySE(4, "ps3/s16/45/ds43070029", 256, 64);
 	OutputLine(NULL, "私を存分に愉しませ、長き星霜のつかの間の慰めとして、その贄となる義務」",
-			NULL, "", Line_Normal);
+			NULL, " I have the obligation to be rewarded by enjoying this to my hearts content, serving as a transient comfort in my many years.\"", Line_Normal);
 	ClearMessage();
 
 //羽入rvS16/45/DS43070030.「それこそが、お前にふさわしき報い…！」
 	PlaySE(4, "ps3/s16/45/ds43070030", 256, 64);
 	OutputLine(NULL, "「それこそが、お前にふさわしき報い…！」",
-			NULL, "", Line_Normal);
+			NULL, "\"That's the retribution you deserve...!\"", Line_Normal);
 	ClearMessage();
 
 	FadeBustshot(4, FALSE, 0, 0, 0, 0, 200, TRUE);
@@ -1224,7 +1224,7 @@ void main()
 
 //rグギャオォォォッッ！！
 	OutputLine(NULL, "グギャオォォォッッ！！",
-			NULL, "", Line_Normal);
+			NULL, "Ggyaoooooooooooooooh!", Line_Normal);
 	ClearMessage();
 
 	DrawScene("background/so5_01", 1000 );
@@ -1234,22 +1234,22 @@ void main()
 //羽入rvS16/45/DS43070031.「…さぁ、立て。kvS16/45/DS43070032.そして踊れ、舞え。kvS16/45/DS43070033.魂を燃やし尽くし、血を絞り出して戦え。kvS16/45/DS43070034.その血と本能に従って戦え。kvS16/45/DS43070035.憎しみと恨みをもって戦え。kvS16/45/DS43070036.戦え。戦え」
 	PlaySE(4, "ps3/s16/45/ds43070031", 256, 64);
 	OutputLine(NULL, "「…さぁ、立て。",
-			NULL, "", Line_WaitForInput);
+			NULL, "\"...Now rise.", Line_WaitForInput);
 	PlaySE(4, "ps3/s16/45/ds43070032", 256, 64);
 	OutputLine(NULL, "そして踊れ、舞え。",
-			NULL, "", Line_WaitForInput);
+			NULL, " Then dance for me.", Line_WaitForInput);
 	PlaySE(4, "ps3/s16/45/ds43070033", 256, 64);
 	OutputLine(NULL, "魂を燃やし尽くし、血を絞り出して戦え。",
-			NULL, "", Line_WaitForInput);
+			NULL, " Burn your soul and squeeze out your blood to fight.", Line_WaitForInput);
 	PlaySE(4, "ps3/s16/45/ds43070034", 256, 64);
 	OutputLine(NULL, "その血と本能に従って戦え。",
-			NULL, "", Line_WaitForInput);
+			NULL, "Fight as your blood's instincts tell you to.", Line_WaitForInput);
 	PlaySE(4, "ps3/s16/45/ds43070035", 256, 64);
 	OutputLine(NULL, "憎しみと恨みをもって戦え。",
-			NULL, "", Line_WaitForInput);
+			NULL, " Fight with grudge and hatred.", Line_WaitForInput);
 	PlaySE(4, "ps3/s16/45/ds43070036", 256, 64);
 	OutputLine(NULL, "戦え。戦え」",
-			NULL, "", Line_Normal);
+			NULL, " Fight. Fight.\"", Line_Normal);
 	ClearMessage();
 
 	PlaySE(3, "dageki", 256, 64);
@@ -1259,16 +1259,16 @@ void main()
 //羽入rvS16/45/DS43070037.「…そして、我が手にかかって死ね！！」
 	PlaySE(4, "ps3/s16/45/ds43070037", 256, 64);
 	OutputLine(NULL, "「…そして、我が手にかかって死ね！！」",
-			NULL, "", Line_Normal);
+			NULL, "\"...Then die by my hand!!\:", Line_Normal);
 	ClearMessage();
 
 //鬼rvS16/00/VT4D_oni1016.（て…撤収だ！！kvS16/00/VT4D_oni1017.　我一人では敵わぬ…違いすぎるッ！！）
 	PlaySE(4, "ps3/s16/00/vt4d_oni1016", 256, 64);
 	OutputLine(NULL, "（て…撤収だ！！",
-			NULL, "", Line_WaitForInput);
+			NULL, "(R-retreat!!", Line_WaitForInput);
 	PlaySE(4, "ps3/s16/00/vt4d_oni1017", 256, 64);
 	OutputLine(NULL, "　我一人では敵わぬ…違いすぎるッ！！）",
-			NULL, "", Line_Normal);
+			NULL, " I can't win on my own... The difference is too great!!)", Line_Normal);
 	ClearMessage();
 
 	PlaySE(3, "furu", 256, 64);
@@ -1281,12 +1281,12 @@ void main()
 
 //rもはや、恐怖を隠すこともなかった。『首領』は大地を蹴って身を翻し、ジェダが立つ場所とは反対の方向へと駆け出す。
 	OutputLine(NULL, "もはや、恐怖を隠すこともなかった。『首領』は大地を蹴って身を翻し、ジェダが立つ場所とは反対の方向へと駆け出す。",
-			NULL, "", Line_Normal);
+			NULL, "The \"chief\", no longer hiding his fear, kicked off the ground and turned around, dashing in the opposite direction of Jedha.", Line_Normal);
 	ClearMessage();
 
 //rだが――。
 	OutputLine(NULL, "だが——。",
-			NULL, "", Line_Normal);
+			NULL, "However...", Line_Normal);
 	ClearMessage();
 
 	DrawScene("background/a/cutin3", 1000 );
@@ -1302,23 +1302,23 @@ void main()
 //鬼rvS16/00/VT4D_oni1018.（ぐあぁぁぁあぁぁっっっ！！）
 	PlaySE(4, "ps3/s16/00/vt4d_oni1018", 256, 64);
 	OutputLine(NULL, "（ぐあぁぁぁあぁぁっっっ！！）",
-			NULL, "", Line_Normal);
+			NULL, "(Gwaaaaaaaaaaaaaaaaaaaaaagh!!)", Line_Normal);
 	ClearMessage();
 
 //羽入rvS16/45/DS43070038.「…逃げる資格は、お前には無い」
 	PlaySE(4, "ps3/s16/45/ds43070038", 256, 64);
 	OutputLine(NULL, "「…逃げる資格は、お前には無い」",
-			NULL, "", Line_Normal);
+			NULL, "\"...You've no right to run.\"", Line_Normal);
 	ClearMessage();
 
 //r瞬く間に距離を詰められ、ジェダの突き出した一撃が『首領』の背を襲い、肺を貫く。
 	OutputLine(NULL, "瞬く間に距離を詰められ、ジェダの突き出した一撃が『首領』の背を襲い、肺を貫く。",
-			NULL, "", Line_Normal);
+			NULL, "Jedha closed the gap between her and the \"chief\" in the blink of an eye, attacked from behind, and pierced his lung.", Line_Normal);
 	ClearMessage();
 
 //rその途端、裂けた口から鮮血が噴水のように吹き出し、目の前が真っ赤に染まっていった。
 	OutputLine(NULL, "その途端、裂けた口から鮮血が噴水のように吹き出し、目の前が真っ赤に染まっていった。",
-			NULL, "", Line_Normal);
+			NULL, "In that very moment, a geyser of blood erupted from his split mouth, dyeing all before him red.", Line_Normal);
 	ClearMessage();
 
 	DrawScene("background/so5_01", 1000 );
@@ -1328,21 +1328,21 @@ void main()
 //羽入rvS16/45/DS43070039.「…ジェダの務めに、未遂の文字はない。kvS16/45/DS43070040.処断を下すか、下されるか。kvS16/45/DS43070041.殺すか、殺されるか。kvS16/45/DS43070042.…それが、『監視者』としての定めであり、我が罪業」
 	PlaySE(4, "ps3/s16/45/ds43070039", 256, 64);
 	OutputLine(NULL, "「…ジェダの務めに、未遂の文字はない。",
-			NULL, "", Line_WaitForInput);
+			NULL, "\"...A Jedha doesn't try. A Jedha <i>does</i>.", Line_WaitForInput);
 	PlaySE(4, "ps3/s16/45/ds43070040", 256, 64);
 	OutputLine(NULL, "処断を下すか、下されるか。",
-			NULL, "", Line_WaitForInput);
+			NULL, " Judge or be judged.", Line_WaitForInput);
 	PlaySE(4, "ps3/s16/45/ds43070041", 256, 64);
 	OutputLine(NULL, "殺すか、殺されるか。",
-			NULL, "", Line_WaitForInput);
+			NULL, " Kill or be killed.", Line_WaitForInput);
 	PlaySE(4, "ps3/s16/45/ds43070042", 256, 64);
 	OutputLine(NULL, "…それが、『監視者』としての定めであり、我が罪業」",
-			NULL, "", Line_Normal);
+			NULL, " ...That's the fate of us Observers.\"", Line_Normal);
 	ClearMessage();
 
 //rギッ、…ギィィッ…！！
 	OutputLine(NULL, "ギッ、…ギィィッ…！！",
-			NULL, "", Line_Normal);
+			NULL, "Ghheee... ghhhheeeeeee...!!", Line_Normal);
 	ClearMessage();
 
 	DrawBustshot( 4, "sprite/normal/oha3_shinken_0", 0, 0, 0, FALSE, 0, 0, 0, 0, 0, 0, 0, 19, 200, TRUE );
@@ -1350,10 +1350,10 @@ void main()
 //羽入rvS16/45/DS43070043.「罪なきこの地の弱者たちを襲い、弄んで殺した貴様。kvS16/45/DS43070044.安寧の日々を送っていた同朋たちを惑わせ、凶気へと駆り立てた貴様」
 	PlaySE(4, "ps3/s16/45/ds43070043", 256, 64);
 	OutputLine(NULL, "「罪なきこの地の弱者たちを襲い、弄んで殺した貴様。",
-			NULL, "", Line_WaitForInput);
+			NULL, "\"You, who attacked the innocent weak in this land, toying with them and killing them.", Line_WaitForInput);
 	PlaySE(4, "ps3/s16/45/ds43070044", 256, 64);
 	OutputLine(NULL, "安寧の日々を送っていた同朋たちを惑わせ、凶気へと駆り立てた貴様」",
-			NULL, "", Line_Normal);
+			NULL, " You, who tricked our brothers and sisters living in peace, goading them into violence.\"", Line_Normal);
 	ClearMessage();
 
 	DrawBustshot( 4, "sprite/normal/oha3_sakebi_0", 0, 0, 0, FALSE, 0, 0, 0, 0, 0, 0, 0, 19, 200, TRUE );
@@ -1361,10 +1361,10 @@ void main()
 //羽入rvS16/45/DS43070045.「…その罪は重く、赦しがたし。kvS16/45/DS43070046.ゆえに、これまでの過ちを記憶から掘り起こし、苦しみ、悶えながらしばしの時間、自らの存在とともに罪業を悔い改めるがいい…」
 	PlaySE(4, "ps3/s16/45/ds43070045", 256, 64);
 	OutputLine(NULL, "「…その罪は重く、赦しがたし。",
-			NULL, "", Line_WaitForInput);
+			NULL, "\"...That sin is grave and all but unforgivable.", Line_WaitForInput);
 	PlaySE(4, "ps3/s16/45/ds43070046", 256, 64);
 	OutputLine(NULL, "ゆえに、これまでの過ちを記憶から掘り起こし、苦しみ、悶えながらしばしの時間、自らの存在とともに罪業を悔い改めるがいい…」",
-			NULL, "", Line_Normal);
+			NULL, " Thus, you shall recall all the mistakes you made up until this point, suffer, and agonize as you spend some time lamenting your existence and sins...\"", Line_Normal);
 	ClearMessage();
 
 	FadeBustshot(4, FALSE, 0, 0, 0, 0, 200, TRUE);
@@ -1373,33 +1373,33 @@ void main()
 
 //rそう言ってジェダは剣を引き抜くと、激痛と呼吸困難にあえぎうずくまる『首領』の前に回り込んで、…かすかな声で詠唱を呟く。
 	OutputLine(NULL, "そう言ってジェダは剣を引き抜くと、激痛と呼吸困難にあえぎうずくまる『首領』の前に回り込んで、…かすかな声で詠唱を呟く。",
-			NULL, "", Line_Normal);
+			NULL, " Jedha pulled out her sword with those words, went around in front of the \"chief\" gasping from immense pain and a lack of oxygen... and began chanting faintly.", Line_Normal);
 	ClearMessage();
 
 //rそれに呼応するかのように、前腕を覆っていた装甲服の袖が消えて、白い肌がむき出しになる。
 	OutputLine(NULL, "それに呼応するかのように、前腕を覆っていた装甲服の袖が消えて、白い肌がむき出しになる。",
-			NULL, "", Line_Normal);
+			NULL, "His armored sleeves disappeared as if acting in concert with that, exposing his white skin.", Line_Normal);
 	ClearMessage();
 
 //rさらに、刀身の血を外套で乱暴に拭い取ってから、右の足をわずかに引いて半身の姿勢となり、前に突き出した左腕にそっ、と剣を這わせた。
 	OutputLine(NULL, "さらに、刀身の血を外套で乱暴に拭い取ってから、右の足をわずかに引いて半身の姿勢となり、前に突き出した左腕にそっ、と剣を這わせた。",
-			NULL, "", Line_Normal);
+			NULL, "Furthermore, after roughly wiping her bloody blade with her cloak, Jedha drew her body back to a half-stance, then ran her sword down her left arm.", Line_Normal);
 	ClearMessage();
 
 //羽入rvS16/45/DS43070047.「――っ…」
 	PlaySE(4, "ps3/s16/45/ds43070047", 256, 64);
 	OutputLine(NULL, "「——っ…」",
-			NULL, "", Line_Normal);
+			NULL, "\"...\"", Line_Normal);
 	ClearMessage();
 
 //r薄く裂かれた傷跡から血があふれだして、その刀身を再びまだらに染めてゆく。
 	OutputLine(NULL, "薄く裂かれた傷跡から血があふれだして、その刀身を再びまだらに染めてゆく。",
-			NULL, "", Line_Normal);
+			NULL, "Blood spilled from the faint wound she'd opened, staining her sword once again.", Line_Normal);
 	ClearMessage();
 
 //rそして、ジェダは長弓を引くように剣を持つ右手を後ろに引くと、まっすぐに片手突きの構えを取った。
 	OutputLine(NULL, "そして、ジェダは長弓を引くように剣を持つ右手を後ろに引くと、まっすぐに片手突きの構えを取った。",
-			NULL, "", Line_Normal);
+			NULL, "Then Jedha pulled her right hand back as if drawing a longbow, holding her sword up in a thrust stance.", Line_Normal);
 	ClearMessage();
 
 	PlaySE(3, "sword", 256, 64);
@@ -1411,35 +1411,35 @@ void main()
 //羽入rvS16/45/DS43070048.「…リューン十八bハィ.<羽爵>のひとり、ジェダの家名を継ぐ者、リューン・クロッソス第３５詞の定めに従いてそなたに問う」
 	PlaySE(4, "ps3/s16/45/ds43070048", 256, 64);
 	OutputLine(NULL, "「…リューン十八羽爵(ハィ)のひとり、ジェダの家名を継ぐ者、リューン・クロッソス第３５詞の定めに従いてそなたに問う」",
-			NULL, "", Line_Normal);
+			NULL, "\"...I, one of the 18 Ryuun Hais, inheritor of the house of Jedha, ask you this in accordance with Ryuun Clossus regulation #35.\"", Line_Normal);
 	ClearMessage();
 
 //羽入rvS16/45/DS43070049.「我ら、リューンの民が天より授かりし宝は誇り高き過去、美しき現在、そして満ち足りた未来…」
 	PlaySE(4, "ps3/s16/45/ds43070049", 256, 64);
 	OutputLine(NULL, "「我ら、リューンの民が天より授かりし宝は誇り高き過去、美しき現在、そして満ち足りた未来…」",
-			NULL, "", Line_Normal);
+			NULL, "\"We of the Ryuun clan have been granted three treasures from the heavens: our proud past, the beautiful present, and a satisfying future...\"", Line_Normal);
 	ClearMessage();
 
 //rガッ、ガァァ……ッ…！
 	OutputLine(NULL, "ガッ、ガァァ……ッ…！",
-			NULL, "", Line_Normal);
+			NULL, "Gaagh, gaaaaaaaagh...!", Line_Normal);
 	ClearMessage();
 
 //羽入rvS16/45/DS43070050.「なれど、掟を破りし同朋に許されるのは、そのうちのひとつのみ。kvS16/45/DS43070051.…最後に、今一度問う。kvS16/45/DS43070052.そなたが欲するのは過去か、現在か…それとも、未来か？」
 	PlaySE(4, "ps3/s16/45/ds43070050", 256, 64);
 	OutputLine(NULL, "「なれど、掟を破りし同朋に許されるのは、そのうちのひとつのみ。",
-			NULL, "", Line_WaitForInput);
+			NULL, "\"However, those of us who defied the laws are given only one of those.", Line_WaitForInput);
 	PlaySE(4, "ps3/s16/45/ds43070051", 256, 64);
 	OutputLine(NULL, "…最後に、今一度問う。",
-			NULL, "", Line_WaitForInput);
+			NULL, " ...I'll ask you only once.", Line_WaitForInput);
 	PlaySE(4, "ps3/s16/45/ds43070052", 256, 64);
 	OutputLine(NULL, "そなたが欲するのは過去か、現在か…それとも、未来か？」",
-			NULL, "", Line_Normal);
+			NULL, " Do you desire the past, present... or future?\"", Line_Normal);
 	ClearMessage();
 
 //rギィ…ギギィッ…！！
 	OutputLine(NULL, "ギィ…ギギィッ…！！",
-			NULL, "", Line_Normal);
+			NULL, Gheeee... gghheeeee...!!"", Line_Normal);
 	ClearMessage();
 
 	DrawScene("scene/410a", 1000 );
@@ -1447,69 +1447,69 @@ void main()
 //羽入rvS16/45/DS43070053.「『助けて』…か」
 	PlaySE(4, "ps3/s16/45/ds43070053", 256, 64);
 	OutputLine(NULL, "「『助けて』…か」",
-			NULL, "", Line_Normal);
+			NULL, "\"Spare me\"... huh?\"", Line_Normal);
 	ClearMessage();
 
 //rギィッ、…ギィ…ッ！！
 	OutputLine(NULL, "ギィッ、…ギィ…ッ！！",
-			NULL, "", Line_Normal);
+			NULL, "Theeee... Ggheeeeeee!!", Line_Normal);
 	ClearMessage();
 
 //羽入rvS16/45/DS43070054.「『許して』…か」
 	PlaySE(4, "ps3/s16/45/ds43070054", 256, 64);
 	OutputLine(NULL, "「『許して』…か」",
-			NULL, "", Line_Normal);
+			NULL, "\"Forgive me\"... huh?\"", Line_Normal);
 	ClearMessage();
 
 //rその言葉の呟きとともに、ジェダの眼光はなおも鋭く、強くなっていく。
 	OutputLine(NULL, "その言葉の呟きとともに、ジェダの眼光はなおも鋭く、強くなっていく。",
-			NULL, "", Line_Normal);
+			NULL, "The glint in Jedha's eye sharpened and intensified with her whispers.", Line_Normal);
 	ClearMessage();
 
 //r怒りでもない。
 	OutputLine(NULL, "怒りでもない。",
-			NULL, "", Line_Normal);
+			NULL, "There was anger in it.", Line_Normal);
 	ClearMessage();
 
 //r愉悦でもない。
 	OutputLine(NULL, "愉悦でもない。",
-			NULL, "", Line_Normal);
+			NULL, "Nor joy.", Line_Normal);
 	ClearMessage();
 
 //rただ、無色透明の『監視者』、そして『処刑執行人』としてのbきょうじ.<矜持>。
 	OutputLine(NULL, "ただ、無色透明の『監視者』、そして『処刑執行人』としての矜持(きょうじ)。",
-			NULL, "", Line_Normal);
+			NULL, "Just her pride as an emotionless Observer and executioner.", Line_Normal);
 	ClearMessage();
 
 //rゆえに――。
 	OutputLine(NULL, "ゆえに——。",
-			NULL, "", Line_Normal);
+			NULL, "Therefore...", Line_Normal);
 	ClearMessage();
 
 //羽入rvS16/45/DS43070055.「…今までにそう哀願した連中に対して、貴様は何をした？」
 	PlaySE(4, "ps3/s16/45/ds43070055", 256, 64);
 	OutputLine(NULL, "「…今までにそう哀願した連中に対して、貴様は何をした？」",
-			NULL, "", Line_Normal);
+			NULL, "\"...What did you do for all the people who begged the same to you?\"", Line_Normal);
 	ClearMessage();
 
 //r全ての情状をさしはさむ余地を持たず、また対象者の命乞いに耳を傾けることもなかった。
 	OutputLine(NULL, "全ての情状をさしはさむ余地を持たず、また対象者の命乞いに耳を傾けることもなかった。",
-			NULL, "", Line_Normal);
+			NULL, "She had no room for compassion, nor the ear to hear out her target's pleas.", Line_Normal);
 	ClearMessage();
 
 //羽入rvS16/45/DS43070056.「空に星を、緑に花を。kvS16/45/DS43070057.あしきゆめには、沈黙のbうた.<詩>。kvS16/45/DS43070058.貴様の未来は、すでに虚無の中にあり。kvS16/45/DS43070059.――ゆえに、ここで散れッッ！！」
 	PlaySE(4, "ps3/s16/45/ds43070056", 256, 64);
 	OutputLine(NULL, "「空に星を、緑に花を。",
-			NULL, "", Line_WaitForInput);
+			NULL, "\"The sky has their stars, the grass their flowers.", Line_WaitForInput);
 	PlaySE(4, "ps3/s16/45/ds43070057", 256, 64);
 	OutputLine(NULL, "あしきゆめには、沈黙の詩(うた)。",
-			NULL, "", Line_WaitForInput);
+			NULL, " A silent poem for wicked dreams.", Line_WaitForInput);
 	PlaySE(4, "ps3/s16/45/ds43070058", 256, 64);
 	OutputLine(NULL, "貴様の未来は、すでに虚無の中にあり。",
-			NULL, "", Line_WaitForInput);
+			NULL, " Your future has already been lost to oblivion.", Line_WaitForInput);
 	PlaySE(4, "ps3/s16/45/ds43070059", 256, 64);
 	OutputLine(NULL, "——ゆえに、ここで散れッッ！！」",
-			NULL, "", Line_Normal);
+			NULL, " ...As such, you will fall here and now!\"", Line_Normal);
 	ClearMessage();
 
 	DrawScene("black", 1000 );
@@ -1520,7 +1520,7 @@ void main()
 
 //rガッ、…ガァァアァァァッッ！！
 	OutputLine(NULL, "ガッ、…ガァァアァァァッッ！！",
-			NULL, "", Line_Normal);
+			NULL, "Gaaaaaagh... gaaaaaaaaaaghhhhhhh!!", Line_Normal);
 	ClearMessage();
 
 	DrawScene("scene/410a", 1000 );
@@ -1528,22 +1528,22 @@ void main()
 //羽入rvS16/45/DS43070060.「ハィ＝リューン・イェアソムール・ジェダ。kvS16/45/DS43070061.それが、貴様の死神の名」
 	PlaySE(4, "ps3/s16/45/ds43070060", 256, 64);
 	OutputLine(NULL, "「ハィ＝リューン・イェアソムール・ジェダ。",
-			NULL, "", Line_WaitForInput);
+			NULL, "\"Hai-Ryuun Yeasomul Jedha", Line_WaitForInput);
 	PlaySE(4, "ps3/s16/45/ds43070061", 256, 64);
 	OutputLine(NULL, "それが、貴様の死神の名」",
-			NULL, "", Line_Normal);
+			NULL, " That's the name of your reaper.\"", Line_Normal);
 	ClearMessage();
 
 //羽入rvS16/45/DS43070062.「――同朋の名を汚す痴れ人よ。…bこんぱく.<魂魄>とともに、逝くがいい」
 	PlaySE(4, "ps3/s16/45/ds43070062", 256, 64);
 	OutputLine(NULL, "「——同朋の名を汚す痴れ人よ。…魂魄(こんぱく)とともに、逝くがいい」",
-			NULL, "", Line_Normal);
+			NULL, "\"Foolish defiler of our kin's name... Perish along with your soul.\"", Line_Normal);
 	ClearMessage();
 
 //羽入rvS16/45/DS43070063.「――っあぁァァッッッ！！」
 	PlaySE(4, "ps3/s16/45/ds43070063", 256, 64);
 	OutputLine(NULL, "「——っあぁァァッッッ！！」",
-			NULL, "", Line_Normal);
+			NULL, "\"...Aaaaaaaaaaaaaaah!!\"", Line_Normal);
 	ClearMessage();
 
 	FadeOutBGM(2, 200, FALSE);
@@ -1566,7 +1566,7 @@ void main()
 
 //rギャァァァアアァァァッッ！！！
 	OutputLine(NULL, "ギャァァァアアァァァッッ！！！",
-			NULL, "", Line_Normal);
+			NULL, "Gggyaaaaaaaaaaaaaagh!!", Line_Normal);
 	ClearMessage();
 
 	PlaySE(3, "addse07", 256, 64);
@@ -1584,31 +1584,31 @@ void main()
 //羽入rvS16/45/DS43070064.「…これでは、蘇生は無理か」
 	PlaySE(4, "ps3/s16/45/ds43070064", 256, 64);
 	OutputLine(NULL, "「…これでは、蘇生は無理か」",
-			NULL, "", Line_Normal);
+			NULL, "\"...No hope of revivial now, huh?\"", Line_Normal);
 	ClearMessage();
 
 //r崩れかけた家屋の陰で、地に伏せっていた男の顔をのぞき見て…ジェダは嘆息する。
 	OutputLine(NULL, "崩れかけた家屋の陰で、地に伏せっていた男の顔をのぞき見て…ジェダは嘆息する。",
-			NULL, "", Line_Normal);
+			NULL, "Jedha looked at the face of a man lying down in the shadow of the collapsing house... and sighed.", Line_Normal);
 	ClearMessage();
 
 //r他の亡骸と比べても深手の傷をいくつも持ち、出血も酷い上、…延髄が破壊されていた。
 	OutputLine(NULL, "他の亡骸と比べても深手の傷をいくつも持ち、出血も酷い上、…延髄が破壊されていた。",
-			NULL, "", Line_Normal);
+			NULL, "Not only had he suffered graver wounds and blood loss than the other corpses... but his medulla oblogata had also been destroyed.", Line_Normal);
 	ClearMessage();
 
 //rおそらく戦いの術すらも持っていなかったのだろうが、その満身創痍の有様を見る限り、守るべきものを守る責務を果たそうとした決死の思いが伝わってくる…。
 	OutputLine(NULL, "おそらく戦いの術すらも持っていなかったのだろうが、その満身創痍の有様を見る限り、守るべきものを守る責務を果たそうとした決死の思いが伝わってくる…。",
-			NULL, "", Line_Normal);
+			NULL, "Judging from the wounds littering his body, he'd desperately fought out of obligation to protect that which he held dear despite possessing no combat skills.", Line_Normal);
 	ClearMessage();
 
 //柳桜rvS16/00/DS43050001.『…イェアソムール・ジェダ、脱出の準備を。kvS16/00/DS43050002.もうすぐ屋敷の中に仕掛けられた、残りの爆薬が引火します』
 	PlaySE(4, "ps3/s16/00/ds43050001", 256, 64);
 	OutputLine(NULL, "『…イェアソムール・ジェダ、脱出の準備を。",
-			NULL, "", Line_WaitForInput);
+			NULL, "\"...Yeasomul Jedha, prepare to evacuate.", Line_WaitForInput);
 	PlaySE(4, "ps3/s16/00/ds43050002", 256, 64);
 	OutputLine(NULL, "もうすぐ屋敷の中に仕掛けられた、残りの爆薬が引火します』",
-			NULL, "", Line_Normal);
+			NULL, " The remaining explosives in the building will soon catch fire.\"", Line_Normal);
 	ClearMessage();
 
 	DrawBustshot( 4, "sprite/normal/oha3_akire_0", 0, 0, 0, FALSE, 0, 0, 0, 0, 0, 0, 0, 19, 200, TRUE );
@@ -1616,22 +1616,22 @@ void main()
 //羽入rvS16/45/DS43070065.「わかっている。kvS16/45/DS43070066.…避難民はどうなった？」
 	PlaySE(4, "ps3/s16/45/ds43070065", 256, 64);
 	OutputLine(NULL, "「わかっている。",
-			NULL, "", Line_WaitForInput);
+			NULL, "\"Got it.", Line_WaitForInput);
 	PlaySE(4, "ps3/s16/45/ds43070066", 256, 64);
 	OutputLine(NULL, "…避難民はどうなった？」",
-			NULL, "", Line_Normal);
+			NULL, " ...What of the evacuees?\"", Line_Normal);
 	ClearMessage();
 
 //柳桜rvS16/00/DS43050003.『問題ありません。kvS16/00/DS43050004.シーツェン・ジェダが追手をすべて撃破しました。kvS16/00/DS43050005.もはや『bグリフィス.<混血>』の気配はどこにも存在しません』
 	PlaySE(4, "ps3/s16/00/ds43050003", 256, 64);
 	OutputLine(NULL, "『問題ありません。",
-			NULL, "", Line_WaitForInput);
+			NULL, "\"There is no problem on that front.", Line_WaitForInput);
 	PlaySE(4, "ps3/s16/00/ds43050004", 256, 64);
 	OutputLine(NULL, "シーツェン・ジェダが追手をすべて撃破しました。",
-			NULL, "", Line_WaitForInput);
+			NULL, " Shezhen Jedha has defeated all pursuers.", Line_WaitForInput);
 	PlaySE(4, "ps3/s16/00/ds43050005", 256, 64);
 	OutputLine(NULL, "もはや『混血(グリフィス)』の気配はどこにも存在しません』",
-			NULL, "", Line_Normal);
+			NULL, " No lingering traces of any Grifys remain.\"", Line_Normal);
 	ClearMessage();
 
 	DrawBustshot( 4, "sprite/normal/oha3_def_0", 0, 0, 0, FALSE, 0, 0, 0, 0, 0, 0, 0, 19, 200, TRUE );
@@ -1639,7 +1639,7 @@ void main()
 //羽入rvS16/45/DS43070067.「…そうか」
 	PlaySE(4, "ps3/s16/45/ds43070067", 256, 64);
 	OutputLine(NULL, "「…そうか」",
-			NULL, "", Line_Normal);
+			NULL, "\"...That so?\"", Line_Normal);
 	ClearMessage();
 
 	PlaySE(3, "dsse16", 256, 64);
@@ -1650,34 +1650,34 @@ void main()
 
 //r脳裏に直接聞こえてきた『声』に返事を送ってから、それでもジェダは引き返さずに奥の部屋へと向かう。
 	OutputLine(NULL, "脳裏に直接聞こえてきた『声』に返事を送ってから、それでもジェダは引き返さずに奥の部屋へと向かう。",
-			NULL, "", Line_Normal);
+			NULL, "However, Jedha defied the \"voice"\ echoing directly in her brain and headed for a room further in.", Line_Normal);
 	ClearMessage();
 
 //r先ほどの戦闘中、この家屋の中からほんの一瞬だが、…何かの気配を感じたのだ。
 	OutputLine(NULL, "先ほどの戦闘中、この家屋の中からほんの一瞬だが、…何かの気配を感じたのだ。",
-			NULL, "", Line_Normal);
+			NULL, "During the fight... she'd sensed something in this house for but the briefest of moments.", Line_Normal);
 	ClearMessage();
 
 //羽入r-vS16/45/DS43070068.（勘が正しければ、この付近に生存者がいるはず…）
 	PlaySE(4, "ps3/s16/45/ds43070068", 256, 64);
 	OutputLine(NULL, "（勘が正しければ、この付近に生存者がいるはず…）",
-			NULL, "", Line_Normal);
+			NULL, "(If my gut's correct, there should be survivors in these parts...)", Line_Normal);
 	ClearMessage();
 
 //rそれに加えて、ここまで抵抗した形跡のある男の亡骸の存在がいっそう、その可能性を裏付ける。
 	OutputLine(NULL, "それに加えて、ここまで抵抗した形跡のある男の亡骸の存在がいっそう、その可能性を裏付ける。",
-			NULL, "", Line_Normal);
+			NULL, "Furthermore, the existence of the corpse who'd fought back with all his might just outside added credibility to the possibility.", Line_Normal);
 	ClearMessage();
 
 //rゆえに一度は立ち去りかけたジェダだが、もう少し調べてみようと思い直し、さらに足を室内に踏み入れていった。
 	OutputLine(NULL, "ゆえに一度は立ち去りかけたジェダだが、もう少し調べてみようと思い直し、さらに足を室内に踏み入れていった。",
-			NULL, "", Line_Normal);
+			NULL, "So even though Jedha had been about to leave, she decided to search a little more carefully, and entered the room.", Line_Normal);
 	ClearMessage();
 
 //羽入rvS16/45/DS43070069.「ん……？」
 	PlaySE(4, "ps3/s16/45/ds43070069", 256, 64);
 	OutputLine(NULL, "「ん……？」",
-			NULL, "", Line_Normal);
+			NULL, "\"Hmm...?\"", Line_Normal);
 	ClearMessage();
 
 	DrawScene("background/honoo", 1000 );
@@ -1686,12 +1686,12 @@ void main()
 
 //rふと、床に転がったものに目を止め、しゃがみ込んで拾い上げる。
 	OutputLine(NULL, "ふと、床に転がったものに目を止め、しゃがみ込んで拾い上げる。",
-			NULL, "", Line_Normal);
+			NULL, "Suddenly, she crouched down to pick up something she'd just spotted on the floor.", Line_Normal);
 	ClearMessage();
 
 //r…それは、小さな人形だった。
 	OutputLine(NULL, "…それは、小さな人形だった。",
-			NULL, "", Line_Normal);
+			NULL, "...It was a small doll.", Line_Normal);
 	ClearMessage();
 
 	DrawBustshot( 4, "sprite/normal/oha3_def_0", 0, 0, 0, FALSE, 0, 0, 0, 0, 0, 0, 0, 19, 200, TRUE );
@@ -1699,24 +1699,24 @@ void main()
 //羽入rvS16/45/DS43070070.「…………」
 	PlaySE(4, "ps3/s16/45/ds43070070", 256, 64);
 	OutputLine(NULL, "「…………」",
-			NULL, "", Line_Normal);
+			NULL, "\"...\"", Line_Normal);
 	ClearMessage();
 
 	FadeBustshot(4, FALSE, 0, 0, 0, 0, 200, TRUE);
 
 //rそれが落ちていたところからさほど離れていない床板のひとつが、少しだけ浮きあがっている。
 	OutputLine(NULL, "それが落ちていたところからさほど離れていない床板のひとつが、少しだけ浮きあがっている。",
-			NULL, "", Line_Normal);
+			NULL, "There was a floorboard not to far from where it'd been lying that was sticking up slightly.", Line_Normal);
 	ClearMessage();
 
 //r違和感を覚えたジェダがそれをこじ開けると、…床板の下は、小さな収納庫になっていた。
 	OutputLine(NULL, "違和感を覚えたジェダがそれをこじ開けると、…床板の下は、小さな収納庫になっていた。",
-			NULL, "", Line_Normal);
+			NULL, "Finding it unusual, Jedha pried it open... and found a small storeroom under the floorboard.", Line_Normal);
 	ClearMessage();
 
 //rのぞき込むと隅の方で、うずくまって倒れている女性の姿が見える。
 	OutputLine(NULL, "のぞき込むと隅の方で、うずくまって倒れている女性の姿が見える。",
-			NULL, "", Line_Normal);
+			NULL, "She spotted a woman lying on the ground there out of the corner of her eye.", Line_Normal);
 	ClearMessage();
 
 	DrawBustshot( 4, "sprite/normal/oha3_def_0", 0, 0, 0, FALSE, 0, 0, 0, 0, 0, 0, 0, 19, 200, TRUE );
@@ -1724,17 +1724,17 @@ void main()
 //羽入rvS16/45/DS43070071.「あ……」
 	PlaySE(4, "ps3/s16/45/ds43070071", 256, 64);
 	OutputLine(NULL, "「あ……」",
-			NULL, "", Line_Normal);
+			NULL, "\"Ah...\"", Line_Normal);
 	ClearMessage();
 
 //rそしてその女性の腕の中では、赤子が守られるように抱かれていた。
 	OutputLine(NULL, "そしてその女性の腕の中では、赤子が守られるように抱かれていた。",
-			NULL, "", Line_Normal);
+			NULL, "The woman was protectively holding a baby in her arms.", Line_Normal);
 	ClearMessage();
 
 //rおそらく母親なのだろう…その女性は出血がひどく、息もすでにない。…それでも、子は辛うじて生きているようだった。
 	OutputLine(NULL, "おそらく母親なのだろう…その女性は出血がひどく、息もすでにない。…それでも、子は辛うじて生きているようだった。",
-			NULL, "", Line_Normal);
+			NULL, "She was probably its mother... but the woman was bleeding heavily and had already ceased breathing... Despite that, the child seemed to be just barely alive.", Line_Normal);
 	ClearMessage();
 
 	DrawBustshot( 4, "sprite/normal/oha3_kanashimi_0", 0, 0, 0, FALSE, 0, 0, 0, 0, 0, 0, 0, 19, 200, TRUE );
@@ -1742,32 +1742,32 @@ void main()
 //羽入rvS16/45/DS43070072.「むぅ…」
 	PlaySE(4, "ps3/s16/45/ds43070072", 256, 64);
 	OutputLine(NULL, "「むぅ…」",
-			NULL, "", Line_Normal);
+			NULL, "\"Mmm...\"", Line_Normal);
 	ClearMessage();
 
 //rすぐに助け出そうとしたが、…ふと、ジェダは差し出した腕を止めて躊躇する。
 	OutputLine(NULL, "すぐに助け出そうとしたが、…ふと、ジェダは差し出した腕を止めて躊躇する。",
-			NULL, "", Line_Normal);
+			NULL, "Jedha immediately held out her arm to save it... but then she stopped midway through.", Line_Normal);
 	ClearMessage();
 
 //rこの地に住まう人間たちの暮らしは、決して楽なものではない。貧しいとまでは言わないが、自分と家族の食物を確保するだけでも精一杯だ。
 	OutputLine(NULL, "この地に住まう人間たちの暮らしは、決して楽なものではない。貧しいとまでは言わないが、自分と家族の食物を確保するだけでも精一杯だ。",
-			NULL, "", Line_Normal);
+			NULL, "Life for people in this region was by no means easy. She wouldn't go so far as to call them poor, but it took everything they had just to provide for their families.", Line_Normal);
 	ClearMessage();
 
 //rまして、この騒乱の直後だ。元の水準に戻すだけでも数年はかかるだろう。
 	OutputLine(NULL, "まして、この騒乱の直後だ。元の水準に戻すだけでも数年はかかるだろう。",
-			NULL, "", Line_Normal);
+			NULL, "But it would take a few years just to return to that standard of living they'd had before this mayhem.", Line_Normal);
 	ClearMessage();
 
 //rそんな中で両親を失い、生活を営む手段など持つはずもない乳飲み子がたどるべき道は、おのずから想像ができる。
 	OutputLine(NULL, "そんな中で両親を失い、生活を営む手段など持つはずもない乳飲み子がたどるべき道は、おのずから想像ができる。",
-			NULL, "", Line_Normal);
+			NULL, "Jedha could easily imagine how an orphaned infant with no means to provide for itself in that aftermath would fare.", Line_Normal);
 	ClearMessage();
 
 //rおそらくはこの先、死ぬよりも重い辛苦が待っていることに違いない…。
 	OutputLine(NULL, "おそらくはこの先、死ぬよりも重い辛苦が待っていることに違いない…。",
-			NULL, "", Line_Normal);
+			NULL, "They'd almost certainly live a life so harsh that death would be the preferrable option...", Line_Normal);
 	ClearMessage();
 
 	DrawBustshot( 4, "sprite/normal/oha3_akire_0", 0, 0, 0, FALSE, 0, 0, 0, 0, 0, 0, 0, 19, 200, TRUE );
@@ -1775,7 +1775,7 @@ void main()
 //羽入r-vS16/45/DS43070073.（それならば、母のそばで――）
 	PlaySE(4, "ps3/s16/45/ds43070073", 256, 64);
 	OutputLine(NULL, "（それならば、母のそばで——）",
-			NULL, "", Line_Normal);
+			NULL, "(In that case, I should leave it with its mother...)", Line_Normal);
 	ClearMessage();
 
 	FadeBustshot(4, FALSE, 0, 0, 0, 0, 200, TRUE);
@@ -1784,7 +1784,7 @@ void main()
 
 //rそう、心の中で呟いて。
 	OutputLine(NULL, "そう、心の中で呟いて。",
-			NULL, "", Line_Normal);
+			NULL, "That was what she told herself.", Line_Normal);
 	ClearMessage();
 
 	FadeOutBGM(2, 200, FALSE);
@@ -1797,7 +1797,7 @@ void main()
 
 //rせめて、ひと思いに逝かせてやろうとジェダは、手に持つ剣を振り上げる。
 	OutputLine(NULL, "せめて、ひと思いに逝かせてやろうとジェダは、手に持つ剣を振り上げる。",
-			NULL, "", Line_Normal);
+			NULL, "And so, figuring the least she could do was give it a merciful death, Jedha raised her sword.", Line_Normal);
 	ClearMessage();
 
 	PlaySE(3, "dsse20", 256, 64);
@@ -1808,23 +1808,23 @@ void main()
 
 //rそして、その切っ先をまっすぐ子供の喉元に――。
 	OutputLine(NULL, "そして、その切っ先をまっすぐ子供の喉元に——。",
-			NULL, "", Line_Normal);
+			NULL, "She then thrust the tip straight towards the child's throat...", Line_Normal);
 	ClearMessage();
 
 //r…………。
 	OutputLine(NULL, "…………。",
-			NULL, "", Line_Normal);
+			NULL, ".........", Line_Normal);
 	ClearMessage();
 
 //r……。
 	OutputLine(NULL, "……。",
-			NULL, "", Line_Normal);
+			NULL, "......", Line_Normal);
 	ClearMessage();
 
 //柳桜rvS16/00/DS43050006.『……ジェダ？』
 	PlaySE(4, "ps3/s16/00/ds43050006", 256, 64);
 	OutputLine(NULL, "『……ジェダ？』",
-			NULL, "", Line_Normal);
+			NULL, "\"...Jedha?\"", Line_Normal);
 	ClearMessage();
 
 	PlayBGM( 1, "honou", 128, 0 );
@@ -1836,16 +1836,16 @@ void main()
 //羽入rvS16/45/DS43070074.「リューン＝オーク。kvS16/45/DS43070075.この付近で、生存者たちが避難した居場所はわかるか？」
 	PlaySE(4, "ps3/s16/45/ds43070074", 256, 64);
 	OutputLine(NULL, "「リューン＝オーク。",
-			NULL, "", Line_WaitForInput);
+			NULL, "\"Ryuun-Ohc.", Line_WaitForInput);
 	PlaySE(4, "ps3/s16/45/ds43070075", 256, 64);
 	OutputLine(NULL, "この付近で、生存者たちが避難した居場所はわかるか？」",
-			NULL, "", Line_Normal);
+			NULL, " Do you know where the survivors evacuated to?\"", Line_Normal);
 	ClearMessage();
 
 //柳桜rvS16/00/DS43050007.『…どうするおつもりです？』
 	PlaySE(4, "ps3/s16/00/ds43050007", 256, 64);
 	OutputLine(NULL, "『…どうするおつもりです？』",
-			NULL, "", Line_Normal);
+			NULL, "\"...What are you planning to do?\"", Line_Normal);
 	ClearMessage();
 
 	DrawBustshot( 4, "sprite/normal/oha3_kanashimi_0", 0, 0, 0, FALSE, 0, 0, 0, 0, 0, 0, 0, 19, 200, TRUE );
@@ -1853,7 +1853,7 @@ void main()
 //羽入rvS16/45/DS43070076.「……」
 	PlaySE(4, "ps3/s16/45/ds43070076", 256, 64);
 	OutputLine(NULL, "「……」",
-			NULL, "", Line_Normal);
+			NULL, "\"...\"", Line_Normal);
 	ClearMessage();
 
 	DrawBustshot( 4, "sprite/normal/oha3_warai_0", 0, 0, 0, FALSE, 0, 0, 0, 0, 0, 0, 0, 19, 200, TRUE );
@@ -1861,12 +1861,12 @@ void main()
 //羽入rvS16/45/DS43070077.「気紛れだ。多少、脚色が必要だろうがな」
 	PlaySE(4, "ps3/s16/45/ds43070077", 256, 64);
 	OutputLine(NULL, "「気紛れだ。多少、脚色が必要だろうがな」",
-			NULL, "", Line_Normal);
+			NULL, "\"Just a whim. This whole thing could use a little dramatization.\"", Line_Normal);
 	ClearMessage();
 
 //rそう言って、ジェダは赤ん坊を母親の胸元から抱きかかえる。そして血泥に汚れたその顔を、そっと指で拭った。
 	OutputLine(NULL, "そう言って、ジェダは赤ん坊を母親の胸元から抱きかかえる。そして血泥に汚れたその顔を、そっと指で拭った。",
-			NULL, "", Line_Normal);
+			NULL, "Jedha took the baby from its mothers' arms, then gently wiped its face covered in blood and mud.", Line_Normal);
 	ClearMessage();
 
 	FadeOutBGM(1, 200, TRUE);
@@ -1886,13 +1886,13 @@ void main()
 //志乃rvS16/00/DS43030001.今はもう、昔の話。
 	PlaySE(4, "ps3/s16/00/ds43030001", 256, 64);
 	OutputLine(NULL, "今はもう、昔の話。",
-			NULL, "", Line_Normal);
+			NULL, "This story has long come and gone.", Line_Normal);
 	ClearMessage();
 
 //志乃rvS16/00/DS43030002.この地に突然、悪い鬼たちが遠い山を越えてやってきました。
 	PlaySE(4, "ps3/s16/00/ds43030002", 256, 64);
 	OutputLine(NULL, "この地に突然、悪い鬼たちが遠い山を越えてやってきました。",
-			NULL, "", Line_Normal);
+			NULL, "Evil demons suddenly crossed distant mountains and arrived in this land.", Line_Normal);
 	ClearMessage();
 
 	DrawScene("scene/sil1a", 1000 );
@@ -1900,13 +1900,13 @@ void main()
 //志乃rvS16/00/DS43030003.鬼たちは食べ物を奪い、家畜を襲い、村人たちに悪さをして暴れまわっていました。
 	PlaySE(4, "ps3/s16/00/ds43030003", 256, 64);
 	OutputLine(NULL, "鬼たちは食べ物を奪い、家畜を襲い、村人たちに悪さをして暴れまわっていました。",
-			NULL, "", Line_Normal);
+			NULL, "The demons stole food, attacked livestock, and went on a rampage doing terrible things to the villagers.", Line_Normal);
 	ClearMessage();
 
 //志乃rvS16/00/DS43030004.しかし、村人たちは何もできませんでした。それを守ろうとした人は殺されて、生き胆を食われてしまうからです。
 	PlaySE(4, "ps3/s16/00/ds43030004", 256, 64);
 	OutputLine(NULL, "しかし、村人たちは何もできませんでした。それを守ろうとした人は殺されて、生き胆を食われてしまうからです。",
-			NULL, "", Line_Normal);
+			NULL, "But the villagers could do nothing. For those who tried to defend them were killed and had their guts eaten live.", Line_Normal);
 	ClearMessage();
 
 	DrawScene("black", 1000 );
@@ -1914,37 +1914,37 @@ void main()
 //志乃rvS16/00/DS43030005.だから、村人たちはいつも家の中に閉じこもって、鬼たちから隠れて暮らすようになりました。
 	PlaySE(4, "ps3/s16/00/ds43030005", 256, 64);
 	OutputLine(NULL, "だから、村人たちはいつも家の中に閉じこもって、鬼たちから隠れて暮らすようになりました。",
-			NULL, "", Line_Normal);
+			NULL, "So the villagers always holed up in their houses and started living in hiding from the demons.", Line_Normal);
 	ClearMessage();
 
 //志乃rvS16/00/DS43030006.夜だけでなく、昼間も。
 	PlaySE(4, "ps3/s16/00/ds43030006", 256, 64);
 	OutputLine(NULL, "夜だけでなく、昼間も。",
-			NULL, "", Line_Normal);
+			NULL, "Not just at night, but in day, too.", Line_Normal);
 	ClearMessage();
 
 //志乃rvS16/00/DS43030007.雨の日も、晴れの日も。
 	PlaySE(4, "ps3/s16/00/ds43030007", 256, 64);
 	OutputLine(NULL, "雨の日も、晴れの日も。",
-			NULL, "", Line_Normal);
+			NULL, "Be it rain, snow, or shine.", Line_Normal);
 	ClearMessage();
 
 //志乃rvS16/00/DS43030008.…それでも鬼たちは、まるで狩りを楽しむように人家を襲い、村人を殺し続けました。
 	PlaySE(4, "ps3/s16/00/ds43030008", 256, 64);
 	OutputLine(NULL, "…それでも鬼たちは、まるで狩りを楽しむように人家を襲い、村人を殺し続けました。",
-			NULL, "", Line_Normal);
+			NULL, "...Yet the demons attacked houses as if enjoying the thrill of the hunt, and continued killing villagers.", Line_Normal);
 	ClearMessage();
 
 //志乃rvS16/00/DS43030009.やがて、田畑から食べ物がなくなり、家の蓄えも底を尽きかけて…。
 	PlaySE(4, "ps3/s16/00/ds43030009", 256, 64);
 	OutputLine(NULL, "やがて、田畑から食べ物がなくなり、家の蓄えも底を尽きかけて…。",
-			NULL, "", Line_Normal);
+			NULL, "Eventually, crops vanished from the fields, and families were on the verge of exhausting their stores.", Line_Normal);
 	ClearMessage();
 
 //志乃rvS16/00/DS43030010.彼らが死を覚悟した、ある日のこと――。
 	PlaySE(4, "ps3/s16/00/ds43030010", 256, 64);
 	OutputLine(NULL, "彼らが死を覚悟した、ある日のこと——。",
-			NULL, "", Line_Normal);
+			NULL, "Then one day, as they were prepared to die...", Line_Normal);
 	ClearMessage();
 
 	DrawScene("scene/sil3b", 1000 );
@@ -1952,7 +1952,7 @@ void main()
 //志乃rvS16/00/DS43030011.村はずれの沼から、ひとりの神様が現れたのです。
 	PlaySE(4, "ps3/s16/00/ds43030011", 256, 64);
 	OutputLine(NULL, "村はずれの沼から、ひとりの神様が現れたのです。",
-			NULL, "", Line_Normal);
+			NULL, "A god emerged from a swamp on the edge of the village.", Line_Normal);
 	ClearMessage();
 
 	DrawScene("scene/sil4b", 1000 );
@@ -1960,7 +1960,7 @@ void main()
 //志乃rvS16/00/DS43030012.神様には、鬼たちと同じように角がありました。そのため、最初は村人たちも鬼がやってきたのだと思って震えあがっていました。
 	PlaySE(4, "ps3/s16/00/ds43030012", 256, 64);
 	OutputLine(NULL, "神様には、鬼たちと同じように角がありました。そのため、最初は村人たちも鬼がやってきたのだと思って震えあがっていました。",
-			NULL, "", Line_Normal);
+			NULL, "The god had horns just like the demons. As such, the villagers trembled in fear at first, believing a demon had come.", Line_Normal);
 	ClearMessage();
 
 	DrawScene("black", 1000 );
@@ -1968,7 +1968,7 @@ void main()
 //志乃rvS16/00/DS43030013.でも、神様が人を襲うことはありませんでした。
 	PlaySE(4, "ps3/s16/00/ds43030013", 256, 64);
 	OutputLine(NULL, "でも、神様が人を襲うことはありませんでした。",
-			NULL, "", Line_Normal);
+			NULL, "But the god did not attack the humans.", Line_Normal);
 	ClearMessage();
 
 	DrawScene("scene/sil6b", 1000 );
@@ -1976,7 +1976,7 @@ void main()
 //志乃rvS16/00/DS43030014.それどころか、神剣をふるい、鬼たちを次々に退治して回り、ついには彼らの王をも倒してしまったのです。
 	PlaySE(4, "ps3/s16/00/ds43030014", 256, 64);
 	OutputLine(NULL, "それどころか、神剣をふるい、鬼たちを次々に退治して回り、ついには彼らの王をも倒してしまったのです。",
-			NULL, "", Line_Normal);
+			NULL, "Instead, the god, wielding a divine blade, exterminated the demons one after another, and finally defeated their king.", Line_Normal);
 	ClearMessage();
 
 	DrawScene("black", 1000 );
@@ -1984,7 +1984,7 @@ void main()
 //志乃rvS16/00/DS43030015.その後神様は、山の洞穴に避難していた村人のひとりの前にやってきて、赤ん坊を差し出しながら言いました…。
 	PlaySE(4, "ps3/s16/00/ds43030015", 256, 64);
 	OutputLine(NULL, "その後神様は、山の洞穴に避難していた村人のひとりの前にやってきて、赤ん坊を差し出しながら言いました…。",
-			NULL, "", Line_Normal);
+			NULL, "Afterwards, the god appeared before one of the villagers who had evacuated to a cave in the mountains, held out a baby to him, and spoke...", Line_Normal);
 	ClearMessage();
 
 	DrawScene("background/so_chikasaishinbu", 1000 );
@@ -1994,13 +1994,13 @@ void main()
 //羽入rvS16/45/DS43070078.『この子は、わが魂の宿る者なり。kvS16/45/DS43070079.ゆえにこの子を育て、血を絶やすことなく大切に敬え。kvS16/45/DS43070080.さすれば、我はお前たちを鬼たちから守り、この村は永遠に栄えるだろう……』
 	PlaySE(4, "ps3/s16/45/ds43070078", 256, 64);
 	OutputLine(NULL, "『この子は、わが魂の宿る者なり。",
-			NULL, "", Line_WaitForInput);
+			NULL, "\"My soul dwells within this child.", Line_WaitForInput);
 	PlaySE(4, "ps3/s16/45/ds43070079", 256, 64);
 	OutputLine(NULL, "ゆえにこの子を育て、血を絶やすことなく大切に敬え。",
-			NULL, "", Line_WaitForInput);
+			NULL, " Therefore, you must raise this child with care and reverence, ensuring death does not befall it.", Line_WaitForInput);
 	PlaySE(4, "ps3/s16/45/ds43070080", 256, 64);
 	OutputLine(NULL, "さすれば、我はお前たちを鬼たちから守り、この村は永遠に栄えるだろう……』",
-			NULL, "", Line_Normal);
+			NULL, " Do this, and I shall defend you from the demons and bring eternal prosperity to this village...\"", Line_Normal);
 	ClearMessage();
 
 	FadeBustshot(4, FALSE, 0, 0, 0, 0, 200, TRUE);
@@ -2010,26 +2010,26 @@ void main()
 //志乃rvS16/00/DS43030016.その赤ん坊は、男の子でした。
 	PlaySE(4, "ps3/s16/00/ds43030016", 256, 64);
 	OutputLine(NULL, "その赤ん坊は、男の子でした。",
-			NULL, "", Line_Normal);
+			NULL, "The baby was a boy.", Line_Normal);
 	ClearMessage();
 
 //志乃rvS16/00/DS43030017.村人たちは神様がこの村を救ってくれたことに心から感謝し、その言葉通り大切に、自分たちの守り神の生まれ変わりとして育てることにしました。
 	PlaySE(4, "ps3/s16/00/ds43030017", 256, 64);
 	OutputLine(NULL, "村人たちは神様がこの村を救ってくれたことに心から感謝し、その言葉通り大切に、自分たちの守り神の生まれ変わりとして育てることにしました。",
-			NULL, "", Line_Normal);
+			NULL, "The villagers gave the god heartfelt thanks for saving their village, and thus took its words as law, raising the boy as the reincarnation of their guardian deity.", Line_Normal);
 	ClearMessage();
 
 //志乃rvS16/00/DS43030018.そして、彼らは角の生えた神様がやってきた沼を『鬼ヶ淵』と名付け、神様によって守られたこの村はいつしか、『鬼ヶ淵村』と呼ばれるようになりました…。
 	PlaySE(4, "ps3/s16/00/ds43030018", 256, 64);
 	OutputLine(NULL, "そして、彼らは角の生えた神様がやってきた沼を『鬼ヶ淵』と名付け、神様によって守られたこの村はいつしか、『鬼ヶ淵村』と呼ばれるようになりました…。",
-			NULL, "", Line_Normal);
+			NULL, "And so they named the swamp the horned god had emerged from \"Onigafuchi\", eventually calling their own village \"Onigafuchi Village\" after the god who'd protected them.", Line_Normal);
 	ClearMessage();
 
 	DrawScene("background/oni1", 1000 );
 
 //r――鬼ヶ淵村伝承『オヤシロさま』
 	OutputLine(NULL, "——鬼ヶ淵村伝承『オヤシロさま』",
-			NULL, "", Line_Normal);
+			NULL, "The Legend of Onigafuchi Village's \"Oyashiro-sama\"", Line_Normal);
 	ClearMessage();
 
 	DrawScene("background/a/cinema", 1000 );


### PR DESCRIPTION
Some various translation notes:

1: Hanyuu's speech pattern: Since later in the route has Riku trying to get Hanyuu to speak more formal/feminine and soundless casual/like a guy, I tried making a conscious effort to make Hanyuu's speech extremely casual and rough to contrast with her change later, though I can't tell if I took it too far.

2: Hanyuu's original name: Since there is no official romanization of Hanyuu's name, I went with "Hai-Ryun Yeasomul Jedha". While the first two names are fairly straightforward, I tried to make the latter two sound as alien and foreign to Japanese ears as possible.

3: Terminology: I explain what Putus and Grifys are in the next script once they get a full-explanation, so I deliberately didn't include the "pureblood" and "half-blood" aspects of their names in this script so it wouldn't sound unnatural.

4: Ryun-Ohc: Again, I tried to make the second half of the name sound alien and foreign to justify Riku's revising of this name later. I considered "Ryun-Ouk" as well, but decided it would be too much of a coincidence for one half of Ouka's namesake to be spelled exactly the same as the Japanese name "Ouka", so I rendered it as "Ryun-Ohc/Ohca" so it still sounds identical but spelled differently.