### PR TITLE
Optional Priority Fixes for review

### DIFF
--- a/Update/haji_003.txt
+++ b/Update/haji_003.txt
@@ -1246,7 +1246,7 @@ void main()
 	Wait( 1000 );
 	ModSetLayerFilter(9, 196, "none");
 	ModSetLayerFilter(9, 256, "none");
-	ModDrawCharacterWithFiltering(9, 2, "sprite/re5_hau_a1_", "0", "down", 0, 240, 0, FALSE, 0, 0, 0, 0, 0, 19, 500, TRUE );
+	ModDrawCharacterWithFiltering(9, 2, "sprite/re5_hau_a1_", "0", "down", 0, 240, 0, FALSE, 0, 0, 0, 0, 0, 19, 500, TRUE ); //ERROR_EXISTING: Priority 19 on layer 9 used here. Conflict is 56 lines away (line 1305)
 
 //rレナの水着は、ちょっぴり大胆なビキニタイプか…！
 	if (GetGlobalFlag(GADVMode)) { OutputLineAll("", NULL, Line_ContinueAfterTyping); }
@@ -1302,7 +1302,7 @@ void main()
 
 	ModDrawCharacter(6, 5, "sprite/ri7_warai_a1_", "0", -300, 0, 0, FALSE, 0, 0, 0, 0, 0, 0, 0, 17, 200, FALSE );
 	ModDrawCharacter(5, 2, "sprite/re5_hau_a1_", "0", -100, 0, 0, FALSE, 0, 0, 0, 0, 0, 0, 0, 18, 200, FALSE );
-	ModDrawCharacter(4, 3, "sprite/me6_wink_a1_", "0", 100, 0, 0, FALSE, 0, 0, 0, 0, 0, 0, 0, 19, 200, FALSE );
+	ModDrawCharacter(4, 3, "sprite/me6_wink_a1_", "0", 100, 0, 0, FALSE, 0, 0, 0, 0, 0, 0, 0, 20, 200, FALSE ); //ERROR: Priority 19 already in use 56 lines ago (line 1249). Existing Layer: 9 Conflicting Layer: 4 Suggested Priority: 20
 	ModDrawCharacter(3, 4, "sprite/sa7_warai_a1_", "0", 300, 0, 0, FALSE, 0, 0, 0, 0, 0, 0, 0, 20, 200, FALSE );
 	DrawScene("background/oki_pool1", 1000 );
 
@@ -1332,7 +1332,7 @@ void main()
 	MoveSprite( 8, -380, -250, -100, 0, 0, 0, 0, 3000, TRUE );
 	Wait( 1000 );
 	ModSetLayerFilter(9, 196, "none");
-	ModDrawCharacterWithFiltering(9, 3, "sprite/me6_wink_a1_", "0", "down", 0, 240, 0, FALSE, 0, 0, 0, 0, 0, 19, 500, TRUE );
+	ModDrawCharacterWithFiltering(9, 3, "sprite/me6_wink_a1_", "0", "down", 0, 240, 0, FALSE, 0, 0, 0, 0, 0, 19, 500, TRUE ); //ERROR_EXISTING: Priority 19 on layer 9 used here. Conflict is 40 lines away (line 1375)
 
 //r魅音の水着は、……何というのか、チャイナドレスみたいな変わった水着だ。
 	if (GetGlobalFlag(GADVMode)) { OutputLineAll("", NULL, Line_ContinueAfterTyping); }
@@ -1372,7 +1372,7 @@ void main()
 
 	ModDrawCharacter(6, 5, "sprite/ri7_warai_a1_", "0", -300, 0, 0, FALSE, 0, 0, 0, 0, 0, 0, 0, 17, 200, FALSE );
 	ModDrawCharacter(5, 2, "sprite/re5_hau_a1_", "0", -100, 0, 0, FALSE, 0, 0, 0, 0, 0, 0, 0, 18, 200, FALSE );
-	ModDrawCharacter(4, 3, "sprite/me6_wink_a1_", "0", 100, 0, 0, FALSE, 0, 0, 0, 0, 0, 0, 0, 19, 200, FALSE );
+	ModDrawCharacter(4, 3, "sprite/me6_wink_a1_", "0", 100, 0, 0, FALSE, 0, 0, 0, 0, 0, 0, 0, 20, 200, FALSE ); //ERROR: Priority 19 already in use 40 lines ago (line 1335). Existing Layer: 9 Conflicting Layer: 4 Suggested Priority: 20
 	ModDrawCharacter(3, 4, "sprite/sa7_hau_a1_", "0", 300, 0, 0, FALSE, 0, 0, 0, 0, 0, 0, 0, 20, 200, FALSE );
 	DrawScene("background/oki_pool1", 1000 );
 
@@ -1405,7 +1405,7 @@ void main()
 	MoveSprite( 8, -380, -250, -100, 0, 0, 0, 0, 3000, TRUE );
 	Wait( 1000 );
 	ModSetLayerFilter(9, 196, "none");
-	ModDrawCharacterWithFiltering(9, 4, "sprite/sa7_hau_a1_", "0", "down", 0, 240, 0, FALSE, 0, 0, 0, 0, 0, 19, 500, TRUE );
+	ModDrawCharacterWithFiltering(9, 4, "sprite/sa7_hau_a1_", "0", "down", 0, 240, 0, FALSE, 0, 0, 0, 0, 0, 19, 500, TRUE ); //ERROR_EXISTING: Priority 19 on layer 9 used here. Conflict is 30 lines away (line 1438)
 
 //rむむ、魅音のあふれんばかりのボリュームを見た後だと、沙都子はだいぶ劣るが、……その年で早くも豊満な未来を予想させるラインは侮りがたし…。
 	if (GetGlobalFlag(GADVMode)) { OutputLineAll("", NULL, Line_ContinueAfterTyping); }
@@ -1435,7 +1435,7 @@ void main()
 
 	ModDrawCharacter(6, 5, "sprite/ri7_warai_a1_", "0", -300, 0, 0, FALSE, 0, 0, 0, 0, 0, 0, 0, 17, 200, FALSE );
 	ModDrawCharacter(5, 2, "sprite/re5_hau_a1_", "0", -100, 0, 0, FALSE, 0, 0, 0, 0, 0, 0, 0, 18, 200, FALSE );
-	ModDrawCharacter(4, 3, "sprite/me6_wink_a1_", "0", 100, 0, 0, FALSE, 0, 0, 0, 0, 0, 0, 0, 19, 200, FALSE );
+	ModDrawCharacter(4, 3, "sprite/me6_wink_a1_", "0", 100, 0, 0, FALSE, 0, 0, 0, 0, 0, 0, 0, 20, 200, FALSE ); //ERROR: Priority 19 already in use 30 lines ago (line 1408). Existing Layer: 9 Conflicting Layer: 4 Suggested Priority: 20
 	ModDrawCharacter(3, 4, "sprite/sa7_hau_a1_", "0", 300, 0, 0, FALSE, 0, 0, 0, 0, 0, 0, 0, 20, 200, FALSE );
 	DrawScene("background/oki_pool1", 1000 );
 
@@ -1590,7 +1590,7 @@ void main()
 	DrawSprite( 8, "sprite/ha_swim", NULL, -380, -700, -100, 0, 0, 0, FALSE, FALSE, 0, 0, 20, 100, TRUE );
 	MoveSprite( 8, -380, -250, -100, 0, 0, 0, 0, 3000, TRUE );
 	Wait( 1000 );
-	ModDrawCharacterWithFiltering(9, 12, "sprite/ha4_warai_", "0", "down", 0, 260, 0, FALSE, 0, 0, 0, 0, 0, 19, 500, TRUE );
+	ModDrawCharacterWithFiltering(9, 12, "sprite/ha4_warai_", "0", "down", 0, 260, 0, FALSE, 0, 0, 0, 0, 0, 19, 500, TRUE ); //ERROR_EXISTING: Priority 19 on layer 9 used here. Conflict is 10 lines away (line 1603)
 
 //羽入rvS23/12/VTH_hanyu1009.「どうですか、とっておきにとっておいたこの水着は？」
 	if (GetGlobalFlag(GADVMode)) { OutputLine("<color=#8676cf>羽入</color>", NULL, "<color=#8676cf>Hanyuu</color>", NULL, Line_ContinueAfterTyping); }
@@ -1600,7 +1600,7 @@ void main()
 	ClearMessage();
 
 	ModSetLayerFilter(2, 256, "none");
-	ModDrawCharacterWithFiltering(2, 5, "sprite/ri7_komaru_a2_", "0", "down", 0, -260, 0, FALSE, 0, 0, 0, 0, 0, 19, 500, TRUE );
+	ModDrawCharacterWithFiltering(2, 5, "sprite/ri7_komaru_a2_", "0", "down", 0, -260, 0, FALSE, 0, 0, 0, 0, 0, 20, 500, TRUE ); //ERROR: Priority 19 already in use 10 lines ago (line 1593). Existing Layer: 9 Conflicting Layer: 2 Suggested Priority: 20ERROR_EXISTING: Priority 19 on layer 2 used here. Conflict is 9 lines away (line 1612)
 
 //梨花rvS23/05/VTH_rika1021.「……圭一もう落ちちゃったけど」
 	if (GetGlobalFlag(GADVMode)) { OutputLine("<color=#6972c1>梨花</color>", NULL, "<color=#6972c1>Rika</color>", NULL, Line_ContinueAfterTyping); }
@@ -1609,7 +1609,7 @@ void main()
 			NULL, "\"...Keiichi already left.\"", Line_Normal);
 	ClearMessage();
 
-	ModDrawCharacter(9, 12, "sprite/ha4_odoroki_", "0", 260, 0, 0, FALSE, 0, 0, 0, 0, 0, 0, 0, 19, 200, TRUE );
+	ModDrawCharacter(9, 12, "sprite/ha4_odoroki_", "0", 260, 0, 0, FALSE, 0, 0, 0, 0, 0, 0, 0, 21, 200, TRUE ); //ERROR: Priority 19 already in use 9 lines ago (line 1603). Existing Layer: 2 Conflicting Layer: 9 Suggested Priority: 21
 
 //羽入rvS23/12/VTH_hanyu1010.「あぅっ？　そ、そんなぁぁ」
 	if (GetGlobalFlag(GADVMode)) { OutputLine("<color=#8676cf>羽入</color>", NULL, "<color=#8676cf>Hanyuu</color>", NULL, Line_ContinueAfterTyping); }

--- a/Update/haji_006.txt
+++ b/Update/haji_006.txt
@@ -37,7 +37,7 @@ void main()
 	Wait( 1000 );
 	ModSetLayerFilter(9, 196, "none");
 	ModSetLayerFilter(9, 256, "none");
-	ModDrawCharacterWithFiltering(9, 9, "sprite/ta6_akuwarai_", "0", "down", 0, 240, 0, FALSE, 0, 0, 0, 0, 0, 19, 500, TRUE );
+	ModDrawCharacterWithFiltering(9, 9, "sprite/ta6_akuwarai_", "0", "down", 0, 240, 0, FALSE, 0, 0, 0, 0, 0, 19, 500, TRUE ); //ERROR_EXISTING: Priority 19 on layer 9 used here. Conflict is 37 lines away (line 77)
 
 //r悩ましげなボディをデッキチェアに晒しながら、通りすがる男たちを流し目で誘惑するのは雛見沢診療所の誘惑ナース、鷹野三四だった。
 	if (GetGlobalFlag(GADVMode)) { OutputLineAll("", NULL, Line_ContinueAfterTyping); }
@@ -74,7 +74,7 @@ void main()
 	ClearMessage();
 
 	ModSetLayerFilter(4, 256, "none");
-	ModDrawCharacter(4, 9, "sprite/ta6_def_", "0", 0, 0, 0, FALSE, 0, 0, 0, 0, 0, 0, 0, 19, 200, FALSE );
+	ModDrawCharacter(4, 9, "sprite/ta6_def_", "0", 0, 0, 0, FALSE, 0, 0, 0, 0, 0, 0, 0, 20, 200, FALSE ); //ERROR: Priority 19 already in use 37 lines ago (line 40). Existing Layer: 9 Conflicting Layer: 4 Suggested Priority: 20
 	DrawScene("background/oki_pool2", 1000 );
 
 //鷹野rvS23/09/VTH_takano1002.「あらあら、魅音ちゃんたちじゃない。kvS23/09/VTH_takano1003.こんにちは。こんなところで奇遇ねぇ」
@@ -218,7 +218,7 @@ void main()
 	MoveSprite( 8, -420, -250, -100, 0, 0, 0, 0, 3000, TRUE );
 	Wait( 1000 );
 	ModSetLayerFilter(9, 196, "none");
-	ModDrawCharacterWithFiltering(9, 22, "sprite/tie2_1_", "0", "down", 0, 240, 0, FALSE, 0, 0, 0, 0, 0, 19, 500, TRUE );
+	ModDrawCharacterWithFiltering(9, 22, "sprite/tie2_1_", "0", "down", 0, 240, 0, FALSE, 0, 0, 0, 0, 0, 19, 500, TRUE ); //ERROR_EXISTING: Priority 19 on layer 9 used here. Conflict is 34 lines away (line 255)
 
 //rカレーが食べられるならどこまでも。例え同伴なしでもプールサイドまで行く教師、華麗なる知恵留美子先生だった。
 	if (GetGlobalFlag(GADVMode)) { OutputLineAll("", NULL, Line_ContinueAfterTyping); }
@@ -252,7 +252,7 @@ void main()
 			NULL, " Just what we need!\"", Line_Normal);
 	ClearMessage();
 
-	ModDrawCharacter(4, 22, "sprite/tie2_1_", "0", 0, 0, 0, FALSE, 0, 0, 0, 0, 0, 0, 0, 19, 200, FALSE );
+	ModDrawCharacter(4, 22, "sprite/tie2_1_", "0", 0, 0, 0, FALSE, 0, 0, 0, 0, 0, 0, 0, 20, 200, FALSE ); //ERROR: Priority 19 already in use 34 lines ago (line 221). Existing Layer: 9 Conflicting Layer: 4 Suggested Priority: 20
 	DrawScene("background/oki_pool2", 1000 );
 
 //知恵rvS23/22/VTH_chie1003.「おやおや、園崎さんたちですか。kvS23/22/VTH_chie1004.こんにちは。皆さんもカレーですか？」

--- a/Update/haji_008.txt
+++ b/Update/haji_008.txt
@@ -1259,7 +1259,7 @@ void main()
 	ModPlayVoiceLS(4, 10, "ps3/s23/10/vth_irie1029", 256, TRUE);
 	OutputLine(NULL, "　これは我が雛見沢ファイターズの秘蔵写真集です！",
 			NULL, " It's a precious photo album full of Hinamizawa Fighters pictures! ", GetGlobalFlag(GLinemodeSp));
-	ModDrawCharacter(4, 10, "sprite/iri4_warai_", "0", 0, 0, 0, FALSE, 0, 0, 0, 0, 0, 0, 0, 19, 200, TRUE );
+	ModDrawCharacter(4, 10, "sprite/iri4_warai_", "0", 0, 0, 0, FALSE, 0, 0, 0, 0, 0, 0, 0, 19, 200, TRUE ); //ERROR_EXISTING: Priority 19 on layer 4 used here. Conflict is 12 lines away (line 1274)
 	if (GetGlobalFlag(GADVMode)) { OutputLine("<color=#c89a80>イリー</color>", NULL, "<color=#c89a80>Irii</color>", NULL, Line_ContinueAfterTyping); }
 	ModPlayVoiceLS(4, 10, "ps3/s23/10/vth_irie1030", 256, TRUE);
 	OutputLine(NULL, "　あなたも知らない無防備な悟史くんの写真が満載！",
@@ -1271,7 +1271,7 @@ void main()
 
 	PlaySE(3, "vse_oppai", 256, 64);
 	DrawBustshot( 6, "waku_w", 0, 0, 0, FALSE, 0, 0, 0, 0, 0, 0, 0, 20, 100, FALSE );
-	ModDrawCharacter(5, 6, "portrait/si4_odoroki_a1_", "0", 0, 0, 0, FALSE, 0, 0, 0, 0, 0, 0, 0, 19, 100, FALSE );
+	ModDrawCharacter(5, 6, "portrait/si4_odoroki_a1_", "0", 0, 0, 0, FALSE, 0, 0, 0, 0, 0, 0, 0, 21, 100, FALSE ); //ERROR: Priority 19 already in use 12 lines ago (line 1262). Existing Layer: 4 Conflicting Layer: 5 Suggested Priority: 21
 	DrawSceneWithMask( "background/imagebg", "v_heart", 0, 0, 500 );
 
 //詩音rvS23/06/VTH_shion1025.「え、えええぇええぇえぇ？！kvS23/06/VTH_shion1026.　おお、お許し下さい、ご主人様ぁあぁ～～！！」
@@ -1296,7 +1296,7 @@ void main()
 	ModPlayVoiceLS(4, 10, "ps3/s23/10/vth_irie1033", 256, TRUE);
 	OutputLine(NULL, "　こちらは鷹野さんのスクラップ帳です！",
 			NULL, " I have Takano-san's scrapbooks right here!", Line_WaitForInput);
-	ModDrawCharacter(4, 10, "sprite/iri4_warai_", "0", 0, 0, 0, FALSE, 0, 0, 0, 0, 0, 0, 0, 19, 200, TRUE );
+	ModDrawCharacter(4, 10, "sprite/iri4_warai_", "0", 0, 0, 0, FALSE, 0, 0, 0, 0, 0, 0, 0, 19, 200, TRUE ); //ERROR_EXISTING: Priority 19 on layer 4 used here. Conflict is 12 lines away (line 1311)
 	ModPlayVoiceLS(4, 10, "ps3/s23/10/vth_irie1034", 256, TRUE);
 	OutputLine(NULL, "　さぁ跪きなさい！！",
 			NULL, " Now, kneel down!!", Line_WaitForInput);
@@ -1308,7 +1308,7 @@ void main()
 	DisableWindow();
 	PlaySE(3, "vse_oppai", 256, 64);
 	DrawBustshot( 7, "waku_w", 0, 0, 0, FALSE, 0, 0, 0, 0, 0, 0, 0, 21, 200, FALSE );
-	ModDrawCharacter(5, 9, "portrait/ta6_kanashimi_", "0", -320, 100, -200, FALSE, 0, 0, 0, 0, 0, 0, 0, 19, 200, FALSE );
+	ModDrawCharacter(5, 9, "portrait/ta6_kanashimi_", "0", -320, 100, -200, FALSE, 0, 0, 0, 0, 0, 0, 0, 22, 200, FALSE ); //ERROR: Priority 19 already in use 12 lines ago (line 1299). Existing Layer: 4 Conflicting Layer: 5 Suggested Priority: 22
 	ModDrawCharacter(6, 6, "portrait/si4_odoroki_a1_", "0", 0, 100, -200, FALSE, 0, 0, 0, 0, 0, 0, 0, 18, 200, FALSE );
 	ModDrawCharacter(3, 22, "portrait/tie2_3_", "0", 320, 100, -200, FALSE, 0, 0, 0, 0, 0, 0, 0, 20, 200, FALSE );
 	DrawSceneWithMask( "background/imagebg", "v_heart", 0, 0, 500 );

--- a/Update/mio_omake_ps3.txt
+++ b/Update/mio_omake_ps3.txt
@@ -140,7 +140,7 @@ void main()
 	ClearMessage();
 
 	FadeBustshot(3, FALSE, 0, 0, 0, 0, 200, TRUE);
-	ModDrawCharacter(3, 22, "sprite/tie_2_", "0", 160, 0, 0, FALSE, 0, 0, 0, 0, 0, 0, 0, 20, 200, TRUE );
+	ModDrawCharacter(3, 22, "sprite/tie_2_", "0", 160, 0, 0, FALSE, 0, 0, 0, 0, 0, 0, 0, 20, 200, TRUE ); //ERROR_EXISTING: Priority 20 on layer 3 used here. Conflict is 24 lines away (line 167)
 
 //知恵rvS20/22/441400051.「そうです、詩音さんは贅沢です！kvS20/22/441400052.　私なんて後半、ほとんど重要なシーンでは登場がなかったというのに！kvS20/22/441400053.　しかも毎回毎回ネタキャラ扱いはどういうことですか？！」
 	if (GetGlobalFlag(GADVMode)) { OutputLine("<color=#68aee5>知恵</color>", NULL, "<color=#68aee5>Chie</color>", NULL, Line_ContinueAfterTyping); }
@@ -164,7 +164,7 @@ void main()
 			NULL, "\"U-uh...don't ask me...\"", Line_Normal);
 	ClearMessage();
 
-	ModDrawCharacter(4, 8, "sprite/tomi3_def_", "0", 160, 0, 0, FALSE, 0, 0, 0, 0, 0, 0, 0, 20, 200, FALSE );
+	ModDrawCharacter(4, 8, "sprite/tomi3_def_", "0", 160, 0, 0, FALSE, 0, 0, 0, 0, 0, 0, 0, 21, 200, FALSE ); //ERROR: Priority 20 already in use 24 lines ago (line 143). Existing Layer: 3 Conflicting Layer: 4 Suggested Priority: 21
 	DrawSceneWithMask( "background/res5", "left", 0, 0, 500 );
 
 //富竹rvS20/08/440800156.「それでも、さすが最終章というだけあって、登場したみんなにそれぞれ見せ場があったよね。kvS20/08/440800157.大石さんの刑事魂、入江所長の医師魂、……お二人の熱い思いがものすごく伝わってきましたよ」
@@ -193,7 +193,7 @@ void main()
 			NULL, " When you came to get me in that scene at the end... I truly felt saved from the bottom of my heart.\"", Line_Normal);
 	ClearMessage();
 
-	ModDrawCharacter(4, 8, "sprite/tomi3_komaru_", "0", 160, 0, 0, FALSE, 0, 0, 0, 0, 0, 0, 0, 20, 200, TRUE );
+	ModDrawCharacter(4, 8, "sprite/tomi3_komaru_", "0", 160, 0, 0, FALSE, 0, 0, 0, 0, 0, 0, 0, 20, 200, TRUE ); //ERROR_EXISTING: Priority 20 on layer 4 used here. Conflict is 9 lines away (line 205)
 
 //富竹rvS20/08/440800158.「あ、いや、あれは……あ、あははは」
 	if (GetGlobalFlag(GADVMode)) { OutputLine("<color=#945c44>富竹</color>", NULL, "<color=#945c44>Tomitake</color>", NULL, Line_ContinueAfterTyping); }
@@ -202,7 +202,7 @@ void main()
 			NULL, "\"Oh, uh, that was... a-ahahaha.\"", Line_Normal);
 	ClearMessage();
 
-	ModDrawCharacter(3, 3, "sprite/me2_akuwarai_a1_", "0", 160, 0, 0, FALSE, 0, 0, 0, 0, 0, 0, 0, 20, 200, FALSE );
+	ModDrawCharacter(3, 3, "sprite/me2_akuwarai_a1_", "0", 160, 0, 0, FALSE, 0, 0, 0, 0, 0, 0, 0, 21, 200, FALSE ); //ERROR: Priority 20 already in use 9 lines ago (line 196). Existing Layer: 4 Conflicting Layer: 3 Suggested Priority: 21
 	DrawSceneWithMask( "background/res1", "left", 0, 0, 500 );
 
 //魅音rvS20/03/440300508.「あー、はいはい。kvS20/03/440300509.なんか一部で勝手に盛り上がってる人たちがいますが、とりあえずほっておこうか」
@@ -1045,7 +1045,7 @@ void main()
 			NULL, "We pray that those honest sentiments from the awkward cast resonate in your hearts, even if only a little.\"", Line_Normal);
 	ClearMessage();
 
-	ModDrawCharacter(5, 2, "sprite/re2a_warai_a1_", "0", -160, 0, 0, FALSE, 0, 0, 0, 0, 0, 0, 0, 18, 200, TRUE );
+	ModDrawCharacter(5, 2, "sprite/re2a_warai_a1_", "0", -160, 0, 0, FALSE, 0, 0, 0, 0, 0, 0, 0, 18, 200, TRUE ); //ERROR_EXISTING: Priority 18 on layer 5 used here. Conflict is 13 lines away (line 1061)
 
 //レナrvS20/02/VTZ_rena1007.「……あ、そろそろいいかな。kvS20/02/VTZ_rena1008.詩ぃちゃん、準備できた？」
 	if (GetGlobalFlag(GADVMode)) { OutputLine("<color=#f0953d>レナ</color>", NULL, "<color=#f0953d>Rena</color>", NULL, Line_ContinueAfterTyping); }
@@ -1058,7 +1058,7 @@ void main()
 	ClearMessage();
 
 	ModSetLayerFilter(1, 256, "none");
-	ModDrawCharacter(1, 6, "sprite/si1b_wink_b1_", "0", 255, 0, 0, FALSE, 0, 0, 0, 0, 0, 0, 0, 18, 200, FALSE );
+	ModDrawCharacter(1, 6, "sprite/si1b_wink_b1_", "0", 255, 0, 0, FALSE, 0, 0, 0, 0, 0, 0, 0, 21, 200, FALSE ); //ERROR: Priority 18 already in use 13 lines ago (line 1048). Existing Layer: 5 Conflicting Layer: 1 Suggested Priority: 21
 	DrawScene("background/res5", 1000 );
 
 //詩音rvS20/06/VTZ_shion1001.「えぇ、ばっちりです。k|yvS20/06/VTZ_shion1002.それじゃ、モニターにつないで……。k|yvS20/06/VTZ_shion1003.もしもし、聞こえますかー？」
@@ -2726,7 +2726,7 @@ void main()
 	ClearMessage();
 
 	FadeOutBGM(2, 200, FALSE);
-	DrawBustshot(9, "eye/live", 0, -300, 125, FALSE, 0, 0, 0, 0, 0, 0, 0, 25, 250, TRUE );
+	DrawBustshot(9, "eye/live", 0, -300, 125, FALSE, 0, 0, 0, 0, 0, 0, 0, 25, 250, TRUE ); //ERROR_EXISTING: Priority 25 on layer 9 used here. Conflict is 328 lines away (line 3057)
 	MoveBustshot(9, NULL, 0, -200, 125, 25, 1000, TRUE );
 	PlaySE(3, "daidageki", 256, 64);
 	ShakeScreen( 1, 15, 15, 2, 0, );
@@ -3054,7 +3054,7 @@ void main()
 	DisableWindow();
 	SetValidityOfInput( FALSE );
 	Wait( 3000 );
-	DrawBustshotWithFiltering(6, "cinema", "x", 1, 0, 0, FALSE, 0, 0, 0, 0, 0, 25, 1300, TRUE );
+	DrawBustshotWithFiltering(6, "cinema", "x", 1, 0, 0, FALSE, 0, 0, 0, 0, 0, 26, 1300, TRUE ); //ERROR: Priority 25 already in use 328 lines ago (line 2729). Existing Layer: 9 Conflicting Layer: 6 Suggested Priority: 26
 	DrawBustshot(7, "title02", 0, 0, 0, FALSE, 0, 0, 0, 0, 0, 0, 0, 26, 3000, TRUE );
 	Wait( 2000 );
 	DrawBustshot(6, "black", 0, 0, 0, FALSE, 0, 0, 0, 0, 0, 0, 0, 25, 3000, TRUE );
@@ -3492,14 +3492,14 @@ void main()
 	ModPlayVoiceLS(4, 3, "ps3/s20/03/440300554", 256, TRUE);
 	OutputLine(NULL, "「それじゃ、最後に全員で皆さんにご挨拶！",
 			NULL, "\"Ok then, one last word from everyone!", Line_WaitForInput);
-	ModDrawCharacter(4, 3, "sprite/me2_wink_a1_", "0", 0, 0, 0, FALSE, 0, 0, 0, 0, 0, 0, 0, 19, 200, TRUE );
+	ModDrawCharacter(4, 3, "sprite/me2_wink_a1_", "0", 0, 0, 0, FALSE, 0, 0, 0, 0, 0, 0, 0, 19, 200, TRUE ); //ERROR_EXISTING: Priority 19 on layer 4 used here. Conflict is 7 lines away (line 3502)
 	ModPlayVoiceLS(4, 3, "ps3/s20/03/440300555", 256, TRUE);
 	OutputLine(NULL, "　音頭は私でいい？　それじゃ、せーのっ」",
 			NULL, " Shall I kick things off? Then one, two, three!\"", Line_Normal);
 	ClearMessage();
 
 	ModDrawCharacter(1, 47, "sprite/ouka1b_warai_", "0", -360, 0, 0, FALSE, 0, 0, 0, 0, 0, 0, 0, 18, 500, FALSE );
-	ModDrawCharacter(2, 46, "sprite/riku_def_", "0", -240, 0, 0, FALSE, 0, 0, 0, 0, 0, 0, 0, 19, 500, FALSE );
+	ModDrawCharacter(2, 46, "sprite/riku_def_", "0", -240, 0, 0, FALSE, 0, 0, 0, 0, 0, 0, 0, 21, 500, FALSE ); //ERROR: Priority 19 already in use 7 lines ago (line 3495). Existing Layer: 4 Conflicting Layer: 2 Suggested Priority: 21
 	ModDrawCharacter(3, 31, "sprite/huji_warai_", "0", -120, 0, 0, FALSE, 0, 0, 0, 0, 0, 0, 0, 17, 500, FALSE );
 	ModDrawCharacter(5, 28, "sprite/tomo1a_warai_", "0", 0, 0, 0, FALSE, 0, 0, 0, 0, 0, 0, 0, 20, 500, FALSE );
 	ModDrawCharacter(6, 29, "sprite/mado2_warai_", "0", 120, 0, 0, FALSE, 0, 0, 0, 0, 0, 0, 0, 16, 500, FALSE );

--- a/Update/mio_omake_switch.txt
+++ b/Update/mio_omake_switch.txt
@@ -131,7 +131,7 @@ void main()
 	ClearMessage();
 
 	FadeBustshot(3, FALSE, 0, 0, 0, 0, 200, TRUE);
-	ModDrawCharacter(3, 22, "sprite/tie_2_", "0", 160, 0, 0, FALSE, 0, 0, 0, 0, 0, 0, 0, 20, 200, TRUE );
+	ModDrawCharacter(3, 22, "sprite/tie_2_", "0", 160, 0, 0, FALSE, 0, 0, 0, 0, 0, 0, 0, 20, 200, TRUE ); //ERROR_EXISTING: Priority 20 on layer 3 used here. Conflict is 24 lines away (line 158)
 
 //知恵rvS20/22/441400051.「そうです、詩音さんは贅沢です！kvS20/22/441400052.　私なんて後半、ほとんど重要なシーンでは登場がなかったというのに！kvS20/22/441400053.　しかも毎回毎回ネタキャラ扱いはどういうことですか？！」
 	if (GetGlobalFlag(GADVMode)) { OutputLine("<color=#68aee5>知恵</color>", NULL, "<color=#68aee5>Chie</color>", NULL, Line_ContinueAfterTyping); }
@@ -155,7 +155,7 @@ void main()
 			NULL, "\"U-uh... don't ask me...\"", Line_Normal);
 	ClearMessage();
 
-	ModDrawCharacter(4, 8, "sprite/tomi3_def_", "0", 160, 0, 0, FALSE, 0, 0, 0, 0, 0, 0, 0, 20, 200, FALSE );
+	ModDrawCharacter(4, 8, "sprite/tomi3_def_", "0", 160, 0, 0, FALSE, 0, 0, 0, 0, 0, 0, 0, 21, 200, FALSE ); //ERROR: Priority 20 already in use 24 lines ago (line 134). Existing Layer: 3 Conflicting Layer: 4 Suggested Priority: 21
 	DrawSceneWithMask( "background/res5", "left", 0, 0, 500 );
 
 //富竹rvS20/08/440800156.「それでも、さすが最終章というだけあって、登場したみんなにそれぞれ見せ場があったよね。kvS20/08/440800157.大石さんの刑事魂、入江所長の医師魂、……お二人の熱い思いがものすごく伝わってきましたよ」
@@ -184,7 +184,7 @@ void main()
 			NULL, " When you came to get me in that scene at the end... I truly felt saved from the bottom of my heart.\"", Line_Normal);
 	ClearMessage();
 
-	ModDrawCharacter(4, 8, "sprite/tomi3_komaru_", "0", 160, 0, 0, FALSE, 0, 0, 0, 0, 0, 0, 0, 20, 200, TRUE );
+	ModDrawCharacter(4, 8, "sprite/tomi3_komaru_", "0", 160, 0, 0, FALSE, 0, 0, 0, 0, 0, 0, 0, 20, 200, TRUE ); //ERROR_EXISTING: Priority 20 on layer 4 used here. Conflict is 9 lines away (line 196)
 
 //富竹rvS20/08/440800158.「あ、いや、あれは……あ、あははは」
 	if (GetGlobalFlag(GADVMode)) { OutputLine("<color=#945c44>富竹</color>", NULL, "<color=#945c44>Tomitake</color>", NULL, Line_ContinueAfterTyping); }
@@ -193,7 +193,7 @@ void main()
 			NULL, "\"Oh, uh, that was... a-ahahaha.\"", Line_Normal);
 	ClearMessage();
 
-	ModDrawCharacter(3, 3, "sprite/me2_akuwarai_a1_", "0", 160, 0, 0, FALSE, 0, 0, 0, 0, 0, 0, 0, 20, 200, FALSE );
+	ModDrawCharacter(3, 3, "sprite/me2_akuwarai_a1_", "0", 160, 0, 0, FALSE, 0, 0, 0, 0, 0, 0, 0, 21, 200, FALSE ); //ERROR: Priority 20 already in use 9 lines ago (line 187). Existing Layer: 4 Conflicting Layer: 3 Suggested Priority: 21
 	DrawSceneWithMask( "background/res1", "left", 0, 0, 500 );
 
 //魅音rvS20/03/440300508.「あー、はいはい。kvS20/03/440300509.なんか一部で勝手に盛り上がってる人たちがいますが、とりあえずほっておこうか」
@@ -1076,7 +1076,7 @@ void main()
 			NULL, "\"It's hard to imagine adding anything more than that, Nipah.\"", Line_Normal);
 	ClearMessage();
 
-	ModDrawCharacter(5, 2, "sprite/re2a_warai_a1_", "0", -120, 0, 0, FALSE, 0, 0, 0, 0, 0, 0, 0, 18, 200, TRUE );
+	ModDrawCharacter(5, 2, "sprite/re2a_warai_a1_", "0", -120, 0, 0, FALSE, 0, 0, 0, 0, 0, 0, 0, 18, 200, TRUE ); //ERROR_EXISTING: Priority 18 on layer 5 used here. Conflict is 13 lines away (line 1092)
 
 //レナrvS20/02/VTZ_rena1007.「……あ、そろそろいいかな。kvS20/02/VTZ_rena1008.詩ぃちゃん、準備できた？」
 	if (GetGlobalFlag(GADVMode)) { OutputLine("<color=#f0953d>レナ</color>", NULL, "<color=#f0953d>Rena</color>", NULL, Line_ContinueAfterTyping); }
@@ -1089,7 +1089,7 @@ void main()
 	ClearMessage();
 
 	ModSetLayerFilter(1, 256, "none");
-	ModDrawCharacter(1, 6, "sprite/si1b_wink_b1_", "0", 255, 0, 0, FALSE, 0, 0, 0, 0, 0, 0, 0, 18, 200, FALSE );
+	ModDrawCharacter(1, 6, "sprite/si1b_wink_b1_", "0", 255, 0, 0, FALSE, 0, 0, 0, 0, 0, 0, 0, 22, 200, FALSE ); //ERROR: Priority 18 already in use 13 lines ago (line 1079). Existing Layer: 5 Conflicting Layer: 1 Suggested Priority: 22
 	DrawScene("background/res5", 1000 );
 
 //詩音rvS20/06/VTZ_shion1001.「えぇ、ばっちりです。k|yvS20/06/VTZ_shion1002.それじゃ、モニターにつないで……。k|yvS20/06/VTZ_shion1003.もしもし、聞こえますかー？」
@@ -4439,14 +4439,14 @@ void main()
 	ModPlayVoiceLS(4, 3, "ps3/s20/03/440300554", 256, TRUE);
 	OutputLine(NULL, "「それじゃ、最後に全員で皆さんにご挨拶！",
 			NULL, "\"Ok then, one last word from everyone!", Line_WaitForInput);
-	ModDrawCharacter(4, 3, "sprite/me2_wink_a1_", "0", 0, 0, 0, FALSE, 0, 0, 0, 0, 0, 0, 0, 19, 200, TRUE );
+	ModDrawCharacter(4, 3, "sprite/me2_wink_a1_", "0", 0, 0, 0, FALSE, 0, 0, 0, 0, 0, 0, 0, 19, 200, TRUE ); //ERROR_EXISTING: Priority 19 on layer 4 used here. Conflict is 7 lines away (line 4449)
 	ModPlayVoiceLS(4, 3, "ps3/s20/03/440300555", 256, TRUE);
 	OutputLine(NULL, "　音頭は私でいい？　それじゃ、せーのっ」",
 			NULL, " Shall I kick things off? Then one, two, three!\"", Line_Normal);
 	ClearMessage();
 
 	ModDrawCharacter(1, 47, "sprite/ouka1b_warai_", "0", -360, 0, 0, FALSE, 0, 0, 0, 0, 0, 0, 0, 18, 500, FALSE );
-	ModDrawCharacter(2, 46, "sprite/riku_def_", "0", -240, 0, 0, FALSE, 0, 0, 0, 0, 0, 0, 0, 19, 500, FALSE );
+	ModDrawCharacter(2, 46, "sprite/riku_def_", "0", -240, 0, 0, FALSE, 0, 0, 0, 0, 0, 0, 0, 21, 500, FALSE ); //ERROR: Priority 19 already in use 7 lines ago (line 4442). Existing Layer: 4 Conflicting Layer: 2 Suggested Priority: 21
 	ModDrawCharacter(3, 31, "sprite/huji_warai_", "0", -120, 0, 0, FALSE, 0, 0, 0, 0, 0, 0, 0, 17, 500, FALSE );
 	ModDrawCharacter(5, 28, "sprite/tomo1a_warai_", "0", 0, 0, 0, FALSE, 0, 0, 0, 0, 0, 0, 0, 20, 500, FALSE );
 	ModDrawCharacter(6, 29, "sprite/mado2_warai_", "0", 120, 0, 0, FALSE, 0, 0, 0, 0, 0, 0, 0, 16, 500, FALSE );

--- a/Update/omot_005_choice2.txt
+++ b/Update/omot_005_choice2.txt
@@ -254,14 +254,14 @@ void main()
 	if (GetLocalFlag(LConsoleArc)==10) {
 		FadeBustshot( 4, FALSE, 0, 0, 0, 0, 200, TRUE );
 		ModDrawCharacter(4, 1, "sprite/kei1_def1_", "0", 0, 0, 0, FALSE, 0, 0, 0, 0, 0, 0, 0, 20, 200, FALSE );
-		ModDrawCharacter(5, 3, "sprite/me1a_def_a1_", "0", -160, 0, 0, FALSE, 0, 0, 0, 0, 0, 0, 0, 19, 200, FALSE );
-		ModDrawCharacter(3, 2, "sprite/re1a_def_a1_", "0", 160, 0, 0, FALSE, 0, 0, 0, 0, 0, 0, 0, 18, 200, FALSE );
+		ModDrawCharacter(5, 3, "sprite/me1a_def_a1_", "0", -160, 0, 0, FALSE, 0, 0, 0, 0, 0, 0, 0, 19, 200, FALSE ); //ERROR_EXISTING: Priority 19 on layer 5 used here. Conflict is 6 lines away (line 263)
+		ModDrawCharacter(3, 2, "sprite/re1a_def_a1_", "0", 160, 0, 0, FALSE, 0, 0, 0, 0, 0, 0, 0, 18, 200, FALSE ); //ERROR_EXISTING: Priority 18 on layer 3 used here. Conflict is 6 lines away (line 264)
 		ModDrawCharacter(6, 4, "sprite/sa1a_def_a1_", "0", -320, 0, 0, FALSE, 0, 0, 0, 0, 0, 0, 0, 17, 200, FALSE );
 		ModDrawCharacter(2, 6, "sprite/si3_def_a1_", "0", 320, 0, 0, FALSE, 0, 0, 0, 0, 0, 0, 0, 16, 200, TRUE );
 	} else {
 		FadeBustshot( 4, FALSE, 0, 0, 0, 0, 200, TRUE );
-		ModDrawCharacter(4, 1, "sprite/kei1_def1_", "0", 0, 0, 0, FALSE, 0, 0, 0, 0, 0, 0, 0, 19, 200, FALSE );
-		ModDrawCharacter(5, 3, "sprite/me1a_def_a1_", "0", -240, 0, 0, FALSE, 0, 0, 0, 0, 0, 0, 0, 18, 200, FALSE );
+		ModDrawCharacter(4, 1, "sprite/kei1_def1_", "0", 0, 0, 0, FALSE, 0, 0, 0, 0, 0, 0, 0, 21, 200, FALSE ); //ERROR: Priority 19 already in use 6 lines ago (line 257). Existing Layer: 5 Conflicting Layer: 4 Suggested Priority: 21
+		ModDrawCharacter(5, 3, "sprite/me1a_def_a1_", "0", -240, 0, 0, FALSE, 0, 0, 0, 0, 0, 0, 0, 22, 200, FALSE ); //ERROR: Priority 18 already in use 6 lines ago (line 258). Existing Layer: 3 Conflicting Layer: 5 Suggested Priority: 22
 		ModDrawCharacter(3, 2, "sprite/re1a_def_a1_", "0", 240, 0, 0, FALSE, 0, 0, 0, 0, 0, 0, 0, 20, 200, TRUE );
 	}
 

--- a/Update/omot_017.txt
+++ b/Update/omot_017.txt
@@ -1496,7 +1496,7 @@ void main()
 			   NULL, "And yet... he was willing to do it...", Line_Normal);
 		ClearMessage();
 
-		ModDrawCharacter(4, 13, "sprite/aks1_def_", "0", 160, 0, 0, FALSE, 0, 0, 0, 0, 0, 0, 0, 20, 100, TRUE );
+		ModDrawCharacter(4, 13, "sprite/aks1_def_", "0", 160, 0, 0, FALSE, 0, 0, 0, 0, 0, 0, 0, 20, 100, TRUE ); //ERROR_EXISTING: Priority 20 on layer 4 used here. Conflict is 52 lines away (line 1551)
 
 		if (GetGlobalFlag(GADVMode)) { OutputLine("<color=#797d8a>赤坂</color>", NULL, "<color=#797d8a>Akasaka</color>", NULL, Line_ContinueAfterTyping); }
 		ModPlayVoiceLS(4, 13, "ps2/13/211300142", 540, TRUE);
@@ -1548,7 +1548,7 @@ void main()
 				NULL, " After a few days of sightseeing in Hinamizawa, my wife and I were planning to go to a private hot spring in Wakura.\"", Line_Normal);
 		ClearMessage();
 
-		ModDrawCharacter(3, 13, "sprite/aks1_def_", "0", 160, 0, 0, FALSE, 0, 0, 0, 0, 0, 0, 0, 20, 200, TRUE );
+		ModDrawCharacter(3, 13, "sprite/aks1_def_", "0", 160, 0, 0, FALSE, 0, 0, 0, 0, 0, 0, 0, 21, 200, TRUE ); //ERROR: Priority 20 already in use 52 lines ago (line 1499). Existing Layer: 4 Conflicting Layer: 3 Suggested Priority: 21
 
 	//赤坂rvS14/13/VT4Bc_akasaka1025.「…だけど、その前に梨花ちゃん。kvS14/13/VT4Bc_akasaka1026.ひとつだけ、教えてほしい」
 		if (GetGlobalFlag(GADVMode)) { OutputLine("<color=#797d8a>赤坂</color>", NULL, "<color=#797d8a>Akasaka</color>", NULL, Line_ContinueAfterTyping); }


### PR DESCRIPTION
Automatically generated scan for when two layers use the same priority. Probably not 100% accurate, and do not trust the automatically generated suggested fixed priority.

@DoctorDiablo  **If you don't have any reported problems of sprites not appearing or other sprite issues, I wouldn't apply any of these fixes**, since two layers using the same priority doesn't always cause problems. It only seems to cause problems under certain conditions, see here for an example: https://github.com/07th-mod/higurashi-assembly/pull/123

But since I already ran this scanner on the other chapters, I thought I might as well post the results here.

----

 - Includes automatically fixed priority on lines with error
 - Please delete //ERROR_EXISTING: comments, those are just to indicate where priority was last used